### PR TITLE
adding getindex for Assessment

### DIFF
--- a/src/utility.jl
+++ b/src/utility.jl
@@ -9,6 +9,10 @@ nested_eltype(x) = nested_eltype(typeof(x))
 nested_eltype(::Type{T}) where T <:AbstractArray = nested_eltype(eltype(T))
 nested_eltype(::Type{T}) where T = T
 
+# Subsetting Assessment
+Base.getindex(A::Assessment, i::Integer) = getfield(A, i)
+Base.getindex(A::Assessment, s::Symbol) = getfield(A, s)
+
 """
 	rowwisenorm(A)
 Computes the row-wise norm of a matrix `A`.


### PR DESCRIPTION
Hey, thanks for implementing this package as it has made it quite easy for me to look into neural bayes estimation. 

Noticed there was no getindex implemented for Assessment struct which might be nice to easily extract the df / runtime 