### PR TITLE
make struct fields concrete

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -4,80 +4,75 @@ on:
   pull_request_target:
     branches:
       - main
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 permissions:
   pull-requests: write
 
 jobs:
-  generate_plots:
-    runs-on: ubuntu-latest
+    generate_plots:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: "1.11"
-      - uses: julia-actions/cache@v2
-      - name: Extract Package Name from Project.toml
-        id: extract-package-name
-        run: |
-          PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
-          echo "::set-output name=package_name::$PACKAGE_NAME"
-      - name: Build AirspeedVelocity
-        env:
-          JULIA_NUM_THREADS: 2
-        run: |
-          # Lightweight build step, as sometimes the runner runs out of memory:
-          julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
-          julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
-      - name: Add ~/.julia/bin to PATH
-        run: |
-          echo "$HOME/.julia/bin" >> $GITHUB_PATH
-      - name: Run benchmarks
-        run: |
-          echo $PATH
-          ls -l ~/.julia/bin
-          mkdir results
-          benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --exeflags="-O3 --threads=auto"
-      - name: Create plots from benchmarks
-        run: |
-          mkdir -p plots
-          benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
-      - name: Upload plot as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: plots
-          path: plots
-      - name: Create markdown table from benchmarks
-        run: |
-          benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
-          echo '### Benchmark Results' > body.md
-          echo '' >> body.md
-          echo '' >> body.md
-          cat table.md >> body.md
-          echo '' >> body.md
-          echo '' >> body.md
-          echo '### Benchmark Plots' >> body.md
-          echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
-          echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
+        steps:
+            - uses: actions/checkout@v4
+            - uses: julia-actions/setup-julia@v2
+              with:
+                version: "1.11"
+            - uses: julia-actions/cache@v2
+            - name: Extract Package Name from Project.toml
+              id: extract-package-name
+              run: |
+                PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+                echo "::set-output name=package_name::$PACKAGE_NAME"
+            - name: Build AirspeedVelocity
+              env:
+                JULIA_NUM_THREADS: 2
+              run: |
+                # Lightweight build step, as sometimes the runner runs out of memory:
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+                julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+            - name: Add ~/.julia/bin to PATH
+              run: |
+                echo "$HOME/.julia/bin" >> $GITHUB_PATH
+            - name: Run benchmarks
+              run: |
+                echo $PATH
+                ls -l ~/.julia/bin
+                mkdir results
+                benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.repository.default_branch}}" --output-dir=results/ --tune
+            - name: Create plots from benchmarks
+              run: |
+                mkdir -p plots
+                benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+            - name: Upload plot as artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: plots
+                path: plots
+            - name: Create markdown table from benchmarks
+              run: |
+                benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+                echo '### Benchmark Results' > body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                cat table.md >> body.md
+                echo '' >> body.md
+                echo '' >> body.md
+                echo '### Benchmark Plots' >> body.md
+                echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
+                echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
 
-      - name: Find Comment
-        uses: peter-evans/find-comment@v3
-        id: fcbenchmark
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: Benchmark Results
+            - name: Find Comment
+              uses: peter-evans/find-comment@v3
+              id: fcbenchmark
+              with:
+                issue-number: ${{ github.event.pull_request.number }}
+                comment-author: 'github-actions[bot]'
+                body-includes: Benchmark Results
 
-      - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: body.md
-          edit-mode: replace
+            - name: Comment on PR
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+                issue-number: ${{ github.event.pull_request.number }}
+                body-path: body.md
+                edit-mode: replace

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 Manifest.toml
 docs/build/
+test/testing-path
 
 .Rproj.user
 .DS_Store

--- a/src/ApproximateDistributions.jl
+++ b/src/ApproximateDistributions.jl
@@ -27,8 +27,8 @@ When using a `GaussianDistribution` as the approximate distribution of a [`Poste
 the neural `network` of the [`PosteriorEstimator`](@ref) should be a mapping from the sample space to ``\mathbb{R}^{|\mathcal{K}|}``, 
 where ``\mathcal{K}`` denotes the space of ``\boldsymbol{\kappa}``. The dimension ``|\mathcal{K}|`` can be determined from an object of type `GaussianDistribution` using [`numdistributionalparams()`](@ref). Given the $|\mathcal{K}|$-dimensional real-valued outputs of the neural network, a valid covariance matrix is constructed internally using [`CovarianceMatrix`](@ref).
 """
-struct GaussianDistribution <: ApproximateDistribution
-	d::Integer
+struct GaussianDistribution{D} <: ApproximateDistribution
+	d::D
     covariancematrix::CovarianceMatrix
 end
 GaussianDistribution(d::Integer) = GaussianDistribution(d, CovarianceMatrix(d))
@@ -190,11 +190,11 @@ where $c = 1.9$ is a fixed clamping threshold. This transformation ensures that 
 
 Additional keyword arguments `kwargs` are passed to the [`MLP`](@ref) constructor when creating `κ₁` and `κ₂`. 
 """
-struct AffineCouplingBlock{M <: MLP}
+struct AffineCouplingBlock{D, M <: MLP}
     scale::M
     translate::M
-    d₁::Integer
-    d₂::Integer
+    d₁::D
+    d₂::D
  end
  
 function AffineCouplingBlock(d₁::Integer, dstar::Integer, d₂::Integer; kwargs...)
@@ -224,10 +224,10 @@ function inverse(net::AffineCouplingBlock, U, V, TZ)
      return θ
 end 
 
-struct CouplingLayer
-    d::Integer
-    d₁::Integer 
-    d₂::Integer
+struct CouplingLayer{D}
+    d::D
+    d₁::D 
+    d₂::D
     block1 
     block2
     actnorm::Union{Nothing, ActNorm}
@@ -314,9 +314,9 @@ where ``d^*`` is an appropriate number of summary statistics for the given param
 - `num_coupling_layers::Integer = 6`: number of coupling layers. 
 - `kwargs`: additional keyword arguments passed to [`AffineCouplingBlock`](@ref). 
 """
-struct NormalisingFlow <: ApproximateDistribution
-	d::Integer  
-    layers::Vector{CouplingLayer}
+struct NormalisingFlow{D} <: ApproximateDistribution
+	d::D  
+    layers::Vector{<:CouplingLayer}
 end
 
 function NormalisingFlow(d::Integer, dstar::Integer; num_coupling_layers::Integer = 6, use_act_norm::Bool = true, kwargs...)

--- a/src/ApproximateDistributions.jl
+++ b/src/ApproximateDistributions.jl
@@ -97,9 +97,9 @@ end
     ActNorm(d::Integer)
 Activation normalisation layer (Kingma and Dhariwal, 2018) for an input of dimension `d`. 
 """
-struct ActNorm
-    scale
-    bias
+struct ActNorm{T1,T2}
+    scale::T1
+    bias::T2
 end
 
 # TODO functionality to initialise based on first batch

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -15,8 +15,8 @@ S(1)
 (S::Vector{Function})(z) = vcat([s(z) for s ∈ S]...)
 
 # NB ideally wouldn't use this, but for backwards compatability I can't remove it now
-struct ElementwiseAggregator
-	a::Function
+struct ElementwiseAggregator{F}
+	a::F
 end
 (e::ElementwiseAggregator)(x::A) where {A <: AbstractArray{T, N}} where {T, N} = e.a(x, dims = N)
 

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -674,9 +674,9 @@ x = rand32(5, 64)
 l(x)
 ```
 """
-struct DensePositive
-	layer::Dense
-	g::Function
+struct DensePositive{L, G}
+	layer::L
+	g::G
 	last_only::Bool
 end
 DensePositive(layer::Dense; g::Function = Flux.relu, last_only::Bool = false) = DensePositive(layer, g, last_only)

--- a/src/Architectures.jl
+++ b/src/Architectures.jl
@@ -369,10 +369,10 @@ Flux.trainable(l::Compress) =  NamedTuple()
 
 #TODO documentation and unit testing
 export TruncateSupport
-struct TruncateSupport
-	a
-	b
-	p::Integer
+struct TruncateSupport{A,B,P}
+	a::A
+	b::B
+	p::P
 end
 function (l::TruncateSupport)(θ::AbstractMatrix)
 	p = l.p
@@ -456,11 +456,11 @@ L = [LowerTriangular(cpu(vectotril(x))) for x ∈ eachcol(L)]
 L[1] * L[1]'
 ```
 """
-struct CovarianceMatrix{T <: Integer}
-  d::T       # dimension of the matrix
-  p::T       # number of free parameters in the covariance matrix, the triangular number d(d+1)÷2
-  tril_idx   # cartesian indices of lower triangle
-  diag_idx   # rows corresponding to the diagonal elements of the d×d covariance matrix   
+struct CovarianceMatrix{T1, T2, I <: Integer}
+  d::I          # dimension of the matrix
+  p::I          # number of free parameters in the covariance matrix, the triangular number d(d+1)÷2
+  tril_idx::T1   # cartesian indices of lower triangle
+  diag_idx::T2   # rows corresponding to the diagonal elements of the d×d covariance matrix   
 end
 function CovarianceMatrix(d::Integer)
 	tril_idx = tril(trues(d, d))

--- a/src/Estimators.jl
+++ b/src/Estimators.jl
@@ -15,8 +15,8 @@ abstract type BayesEstimator <: NeuralEstimator  end
     PointEstimator(network)
 A neural point estimator, where the neural `network` is a mapping from the sample space to the parameter space.
 """
-struct PointEstimator <: BayesEstimator
-	network 
+struct PointEstimator{N} <: BayesEstimator
+	network::N 
 end
 (estimator::PointEstimator)(Z) = estimator.network(Z)
 
@@ -75,12 +75,12 @@ estimate(estimator, Z)
 interval(estimator, Z)
 ```
 """
-struct IntervalEstimator{N, H} <: BayesEstimator
+struct IntervalEstimator{N, H, C, G} <: BayesEstimator
 	u::N 
 	v::N
-	c::Union{Function,Compress}
+	c::C
 	probs::H
-	g::Function
+	g::G
 end
 function IntervalEstimator(u, v = u, c::Union{Function, Compress} = identity; probs = [0.025, 0.975], g = exp)
 	if !isa(probs, AbstractArray)
@@ -198,11 +198,11 @@ q₁(Z, θ₋ᵢ)
 q₁(Z[1], θ₋ᵢ)
 ```
 """
-struct QuantileEstimator{V, P} <: BayesEstimator #TODO function for neat output as dxT matrix like interval() 
+struct QuantileEstimator{V, P, G, I} <: BayesEstimator #TODO function for neat output as dxT matrix like interval() 
 	v::V
 	probs::P
-	g::Union{Function, Nothing}
-	i::Union{Integer, Nothing}
+	g::G
+	i::I
 end
 function QuantileEstimator(v; probs = [0.025, 0.5, 0.975], g = Flux.softplus, i::Union{Integer, Nothing} = nothing)
 	if !isa(probs, AbstractArray)
@@ -376,9 +376,9 @@ q̂ᵢ(Z, θ₋ᵢ, τ)
 q̂ᵢ(Z[1], θ₋ᵢ, τ)
 ```
 """
-struct QuantileEstimatorContinuous{N} <: NeuralEstimator
+struct QuantileEstimatorContinuous{N, I} <: NeuralEstimator
 	network::N 
-	i::Union{Integer, Nothing}
+	i::I
 end
 function QuantileEstimatorContinuous(network; i::Union{Integer, Nothing} = nothing)
 	if !isnothing(i) @assert i > 0 end
@@ -459,9 +459,9 @@ sampleposterior(estimator, Z) # posterior draws
 posteriormean(estimator, Z)   # point estimate
 ```
 """
-struct PosteriorEstimator <: NeuralEstimator
-	q::ApproximateDistribution
-	network
+struct PosteriorEstimator{Q,N} <: NeuralEstimator
+	q::Q
+	network::N
 end
 numdistributionalparams(estimator::PosteriorEstimator) = numdistributionalparams(estimator.q)
 logdensity(estimator::PosteriorEstimator, θ, Z) = logdensity(estimator.q, f32(θ), estimator.network(f32(Z))) 
@@ -658,10 +658,10 @@ Z = [rand(n, m) for m ∈ (10, 50)]
 estimate(θ̂, Z)
 ```
 """
-struct PiecewiseEstimator <: NeuralEstimator
-	estimators
-	changepoints
-	function PiecewiseEstimator(estimators, changepoints)
+struct PiecewiseEstimator{E, C} <: NeuralEstimator
+	estimators::E
+	changepoints::C
+	function PiecewiseEstimator(estimators, changepoints) 
 		if isa(changepoints, Number)
 			changepoints = [changepoints]
 		end
@@ -671,7 +671,9 @@ struct PiecewiseEstimator <: NeuralEstimator
 		elseif !issorted(changepoints)
 			error("`changepoints` should be in ascending order")
 		else
-			new(estimators, changepoints)
+			E = typeof(estimators)
+			C = typeof(changepoints)
+			new{E,C}(estimators, changepoints)
 		end
 	end
 end

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -212,9 +212,9 @@ h = rand(1, 30) # distances between 30 pairs of spatial locations
 w(h)
 ```
 """ 
-struct KernelWeights 
-	mu 
-	sigma 
+struct KernelWeights{T1,T2} 
+	mu::T1 
+	sigma::T2 
 end 
 function KernelWeights(h_max, n_bins::Integer) 
 	h_cutoffs = range(0, stop=h_max, length=n_bins+1) 

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -82,10 +82,10 @@ subsetparameters(θ::M, indices::Integer) where {M <: AbstractMatrix} = subsetpa
 
 struct _ParameterLoader{P <: Union{AbstractMatrix, ParameterConfigurations}, I <: Integer}
     parameters::P
-    batchsize::Integer
-    nobs::Integer
+    batchsize::I
+    nobs::I
     partial::Bool
-    imax::Integer
+    imax::I
     indices::Vector{I}
     shuffle::Bool
 end


### PR DESCRIPTION
Hi, 

I saw on your TODO list an entry for performance improvements. The easiest starting point seemed to be making the field types of struct concrete. This PR fixes those issues, but there were a few union types (e.g., [here](https://github.com/itsdfish/NeuralEstimators.jl/blob/199a7303265d887f2c94373dbd864acf4b78050b/src/Graphs.jl#L352)). Sometimes those can be fixed, other times they can't. Often a union of two types does not incur much of a performance penalty. 

An issue not related to performance is whether you would like to put constraints on the parametric types. Its not necessary for performance, but it can help the user, especially if the doc strings contain info about fields and types. 

Typically, I add this to my documentation:

```julia 
"""
         MyStruct{T <: Number}
Some documentation here.

# Fields 

- `x::T`: some info here
"""
 struct MyStruct{T <: Number}
       x::T
 end
 ```
 
 I would be willing to add any of the above to the PR if you would like. 