### PR TITLE
add benchmarks

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,0 +1,88 @@
+name: Benchmark a pull request
+
+on:
+  pull_request_target:
+    branches:
+      - master
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+permissions:
+  pull-requests: write
+
+jobs:
+  generate_plots:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+      - name: Extract Package Name from Project.toml
+        id: extract-package-name
+        run: |
+          PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+          echo "::set-output name=package_name::$PACKAGE_NAME"
+        with:
+          version: "1.11"
+      - uses: julia-actions/cache@v2
+      - name: Extract Package Name from Project.toml
+        id: extract-package-name
+        run: |
+          PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
+          echo "::set-output name=package_name::$PACKAGE_NAME"
+      - name: Build AirspeedVelocity
+        env:
+          JULIA_NUM_THREADS: 2
+        run: |
+          # Lightweight build step, as sometimes the runner runs out of memory:
+          julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.add(;url="https://github.com/MilesCranmer/AirspeedVelocity.jl.git")'
+          julia -e 'ENV["JULIA_PKG_PRECOMPILE_AUTO"]=0; import Pkg; Pkg.build("AirspeedVelocity")'
+      - name: Add ~/.julia/bin to PATH
+        run: |
+          echo "$HOME/.julia/bin" >> $GITHUB_PATH
+      - name: Run benchmarks
+        run: |
+          echo $PATH
+          ls -l ~/.julia/bin
+          mkdir results
+          benchpkg ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --url=${{ github.event.repository.clone_url }} --bench-on="${{github.event.pull_request.head.sha}}" --output-dir=results/ --exeflags="-O3 --threads=auto"
+      - name: Create plots from benchmarks
+        run: |
+          mkdir -p plots
+          benchpkgplot ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --npart=10 --format=png --input-dir=results/ --output-dir=plots/
+      - name: Upload plot as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plots
+          path: plots
+      - name: Create markdown table from benchmarks
+        run: |
+          benchpkgtable ${{ steps.extract-package-name.outputs.package_name }} --rev="${{github.event.repository.default_branch}},${{github.event.pull_request.head.sha}}" --input-dir=results/ --ratio > table.md
+          echo '### Benchmark Results' > body.md
+          echo '' >> body.md
+          echo '' >> body.md
+          cat table.md >> body.md
+          echo '' >> body.md
+          echo '' >> body.md
+          echo '### Benchmark Plots' >> body.md
+          echo 'A plot of the benchmark results have been uploaded as an artifact to the workflow run for this PR.' >> body.md
+          echo 'Go to "Actions"->"Benchmark a pull request"->[the most recent run]->"Artifacts" (at the bottom).' >> body.md
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v3
+        id: fcbenchmark
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Benchmark Results
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fcbenchmark.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: body.md
+          edit-mode: replace

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
-/Manifest.toml
+Manifest.toml
 docs/build/
 
 .Rproj.user

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+BenchmarkPlots = "ab8c0f59-4072-4e0d-8f91-a91e1495eb26"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+NeuralEstimators = "38f6df31-6b4a-4144-b2af-7ace2da57606"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,381 @@
+##############################################################################################################
+#                                             load packages
+##############################################################################################################
+using BenchmarkTools
+using Distributions: Normal
+using Distributions: Uniform
+using Flux 
+using NeuralEstimators
+using NeuralEstimators: ActNorm
+using NeuralEstimators: CouplingLayer
+using NeuralEstimators: forward
+using NeuralEstimators: inverse
+using NeuralEstimators: Permutation
+##############################################################################################################
+#                                                   setup
+##############################################################################################################
+n = 2        # dimension of each data replicate 
+m = 5        # number of independent replicates 
+d = 2        # dimension of the parameter vector θ
+w = 128      # width of each hidden layer 
+
+function sample(K)
+    μ = rand(Normal(0, 10), K)
+    σ = rand(Uniform(0, 10), K)
+    θ = vcat(μ', σ')
+    return θ
+end
+
+simulate(θ, m) = [ϑ[1] .+ ϑ[2] * randn(n, m) for ϑ ∈ eachcol(θ)]
+
+SUITE = BenchmarkGroup()
+##############################################################################################################
+#                                             PointEstimator
+##############################################################################################################
+SUITE[:PointEstimator] = BenchmarkGroup()
+
+final_layer = Parallel(
+    vcat,
+    Dense(w, 1, identity),     # μ ∈ ℝ
+    Dense(w, 1, softplus)      # σ > 0
+)
+
+estimator = PointEstimator(DeepSet(
+    Chain(Dense(n, w, relu), Dense(w, d, relu)), 
+    Chain(Dense(d, w, relu), final_layer)
+))
+
+SUITE[:PointEstimator][:train] = @benchmarkable(
+    train($estimator, $sample, simulate, epochs = 5, m = $m),
+    seconds = 30,
+)
+
+SUITE[:PointEstimator][:estimate] = @benchmarkable(
+    estimate($estimator, data),
+    setup = (data = simulate([5, 0.3], $m))
+)
+
+SUITE = BenchmarkGroup()
+SUITE[:PointEstimator] = BenchmarkGroup()
+
+for B ∈ [1000, 5000]
+    SUITE[:PointEstimator][:bootstrap,B] = @benchmarkable(
+        bootstrap($estimator, data; B = $B),
+        setup = (data = simulate([5, 0.3], $m))
+    )
+end
+
+SUITE[:PointEstimator][:assess] = @benchmarkable(
+    assess($estimator, prior_samples, data),
+    seconds = 10,
+    setup = (
+        prior_samples = sample(1000); 
+        data = simulate(prior_samples, $m)
+    )
+)
+##############################################################################################################
+#                                             RatioEstimator
+##############################################################################################################
+SUITE[:RatioEstimator] = BenchmarkGroup()
+
+estimator = RatioEstimator(DeepSet(
+    Chain(Dense(n, w, relu), Dense(w, w, relu), Dense(w, w, relu)), 
+    Chain(Dense(w + d, w, relu), Dense(w, w, relu), Dense(w, 1))
+))
+
+SUITE[:RatioEstimator][:train] = @benchmarkable(
+    train($estimator, $sample, simulate, epochs = 5, m = $m),
+    seconds = 30,
+)
+
+SUITE[:RatioEstimator][:sampleposterior] = @benchmarkable(
+    sampleposterior($estimator, data),
+    setup = (data = simulate([5, 0.3], $m))
+)
+
+SUITE[:RatioEstimator][:mlestimate] = @benchmarkable(
+    mlestimate($estimator, data; θ_grid),
+    setup = (
+        data = simulate([5, 0.3], $m);
+        θ_grid = f32(expandgrid(0:0.01:1, 0:0.01:1))'    
+    )
+)
+
+SUITE[:RatioEstimator][:posteriormean] = @benchmarkable(
+    posteriormean($estimator, data; θ_grid),
+    setup = (
+        data = simulate([5, 0.3], $m);
+        θ_grid = f32(expandgrid(0:0.01:1, 0:0.01:1))'    
+    )
+)
+
+SUITE[:RatioEstimator][:posteriormode] = @benchmarkable(
+    posteriormode($estimator, data; θ_grid),
+    setup = (
+        data = simulate([5, 0.3], $m);
+        θ_grid = f32(expandgrid(0:0.01:1, 0:0.01:1))'    
+    )
+)
+
+SUITE[:RatioEstimator][:posteriormedian] = @benchmarkable(
+    posteriormedian($estimator, data; θ_grid),
+    setup = (
+        data = simulate([5, 0.3], $m);
+        θ_grid = f32(expandgrid(0:0.01:1, 0:0.01:1))'    
+    )
+)
+
+SUITE[:RatioEstimator][:sampleposterior] = @benchmarkable(
+    sampleposterior($estimator, data; θ_grid),
+    setup = (
+        data = simulate([5, 0.3], $m);
+        θ_grid = f32(expandgrid(0:0.01:1, 0:0.01:1))'    
+    )
+)
+##############################################################################################################
+#                                             PosteriorEstimator
+##############################################################################################################
+SUITE[:PosteriorEstimator] = BenchmarkGroup()
+
+estimator = PosteriorEstimator(
+    NormalisingFlow(d, 2 * d), 
+    DeepSet(
+        Chain(Dense(n, w, relu), Dense(w, w, relu)),
+        Chain(Dense(w, w, relu), Dense(w, 2 * d))
+    )   
+)
+
+SUITE[:PosteriorEstimator][:train] = @benchmarkable(
+    train($estimator, $sample, simulate, epochs = 5, m = $m),
+    seconds = 30,
+)
+
+SUITE[:PosteriorEstimator][:sampleposterior] = @benchmarkable(
+    sampleposterior($estimator, data),
+    setup = (data = simulate([5, 0.3], $m))
+)
+
+SUITE[:PosteriorEstimator][:posteriormean] = @benchmarkable(
+    posteriormean($estimator, data),
+    setup = (data = simulate([5, 0.3], $m))
+)
+
+SUITE[:PosteriorEstimator][:posteriormedian] = @benchmarkable(
+    posteriormedian($estimator, data),
+    setup = (data = simulate([5, 0.3], $m))
+)
+
+SUITE[:PosteriorEstimator][:posteriorquantile] = @benchmarkable(
+    posteriorquantile($estimator, data, probs),
+    setup = (data = simulate([5, 0.3], $m); probs = [.025, .975])
+)
+
+SUITE[:PosteriorEstimator][:assess] = @benchmarkable(
+    assess($estimator, prior_samples, data),
+    seconds = 10,
+    setup = (
+        prior_samples = sample(1000); 
+        data = simulate(prior_samples, $m)
+    )
+)
+##############################################################################################################
+#                                             assessment functions
+##############################################################################################################
+# assement functions are performed once---I don't think assessment functions depend on neural estimation method
+SUITE[:assessments] = BenchmarkGroup()
+# create assessment; too slow for setup
+prior_samples = sample(1000)
+data = simulate(prior_samples, m)
+assessment = assess(estimator, prior_samples, data)
+
+SUITE[:assessments][:risk] = @benchmarkable(
+    risk($assessment),
+)
+
+SUITE[:assessments][:bias] = @benchmarkable(
+    bias($assessment),
+)
+
+SUITE[:assessments][:rmse] = @benchmarkable(
+    rmse($assessment),
+)
+##############################################################################################################
+#                                             Layers
+##############################################################################################################
+SUITE[:layers] = BenchmarkGroup()
+SUITE[:layers][:compress] = @benchmarkable(
+    l(θ),
+    setup = (
+        a = [25, 0.5, -pi/2];
+        b = [500, 2.5, 0];
+        p = length(a);
+        K = 100;
+        θ = randn(p, K);
+        l = Compress(a, b);
+    )
+)
+
+for m ∈ [10, 100]
+    SUITE[:layers][:deepset,m] = @benchmarkable(
+        deepset(data),
+        setup = (
+            d = 4;
+            n = 100;
+            w = 128;
+            deepset = DeepSet(
+                Chain(Dense(n, w, $relu), Dense(w, w, $relu)),
+                Chain(Dense(w, w, $relu), Dense(w, 2 * d))
+            );
+            data = [rand32(n, $m)] 
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:AffineCouplingBlock][:foward,K] = @benchmarkable(
+        forward(layer, θ2, θ1, TZ),
+        setup = (
+            d₁ = 100;
+            dstar = 50; 
+            d₂ = 100;
+            θ1  = rand32(d₁, $K);
+            θ2  = rand32(d₁, $K);
+            TZ  = rand32(dstar, $K);
+            layer = AffineCouplingBlock(d₁, dstar, d₂);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:AffineCouplingBlock][:inverse,K] = @benchmarkable(
+        inverse(layer, θ1, U2[1], TZ),
+        setup = (
+            d₁ = 100;
+            dstar = 50;
+            d₂ = 100;
+            θ1  = rand32(d₁, $K);
+            θ2  = rand32(d₁, $K);
+            TZ  = rand32(dstar, $K);
+            layer = AffineCouplingBlock(d₁, dstar, d₂);
+            U2 = forward(layer, θ2, θ1, TZ); 
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:CouplingLayer][:forward,K] = @benchmarkable(
+        forward(layer, θ, TZ),
+        setup = (
+            d = 100;
+            dstar = 50;
+            θ = rand32(d, $K);
+            TZ = rand32(dstar, $K);
+            layer = CouplingLayer(d, dstar);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:CouplingLayer][:inverse,K] = @benchmarkable(
+        inverse(layer, U[1], TZ),
+        setup = (
+            d = 100;
+            dstar = 50;
+            θ = rand32(d, $K);
+            TZ = rand32(dstar, $K);
+            layer = CouplingLayer(d, dstar);
+            U = forward(layer, θ, TZ); 
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:NormalisingFlow][:forward,K] = @benchmarkable(
+        forward(layer, θ, TZ),
+        setup = (
+            d = 100;
+            dstar = 50;
+            θ = rand32(d, $K);
+            TZ = rand32(dstar, $K);
+            layer = NormalisingFlow(d, dstar);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:NormalisingFlow][:inverse,K] = @benchmarkable(
+        inverse(layer, U[1], TZ),
+        setup = (
+            d = 100;
+            dstar = 50;
+            θ = rand32(d, $K);
+            TZ = rand32(dstar, $K);
+            layer = NormalisingFlow(d, dstar);
+            U = forward(layer, θ, TZ);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:NormalisingFlow][:logdensity,K] = @benchmarkable(
+        logdensity(layer, θ, TZ),
+        setup = (
+            d = 100;
+            dstar = 50;
+            θ = rand32(d, $K);
+            TZ = rand32(dstar, $K);
+            layer = NormalisingFlow(d, dstar);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:Permutation][:forward,K] = @benchmarkable(
+        forward(layer, θ),
+        setup = (
+            d = 100;
+            θ = rand32(d, $K);
+            layer = Permutation(d);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:Permutation][:inverse,K] = @benchmarkable(
+        inverse(layer, U),
+        setup = (
+            d = 100;
+            θ = rand32(d, $K);
+            layer = Permutation(d);
+            U = forward(layer, θ);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:ActNorm][:forward,K] = @benchmarkable(
+        forward(layer, θ),
+        setup = (
+            d = 100;
+            θ = rand32(d, $K);
+            layer = ActNorm(d);
+        )
+    )
+end
+
+for K ∈ [5, 10]
+    SUITE[:layers][:ActNorm][:inverse,K] = @benchmarkable(
+        inverse(layer, U[1]),
+        setup = (
+            d = 100;
+            θ = rand32(d, $K);
+            layer = ActNorm(d);
+            U = forward(layer, θ);
+        )
+    )
+end
+
+# SUITE = BenchmarkGroup()
+# SUITE[:layers] = BenchmarkGroup()
+
+results = run(SUITE) 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -55,9 +55,6 @@ SUITE[:PointEstimator][:estimate] = @benchmarkable(
     setup = (data = simulate([5, 0.3], $m))
 )
 
-SUITE = BenchmarkGroup()
-SUITE[:PointEstimator] = BenchmarkGroup()
-
 for B ∈ [1000, 5000]
     SUITE[:PointEstimator][:bootstrap,B] = @benchmarkable(
         bootstrap($estimator, data; B = $B),
@@ -374,8 +371,5 @@ for K ∈ [5, 10]
         )
     )
 end
-
-# SUITE = BenchmarkGroup()
-# SUITE[:layers] = BenchmarkGroup()
 
 results = run(SUITE) 

--- a/benchmark/compare_benchmarks.jl
+++ b/benchmark/compare_benchmarks.jl
@@ -1,0 +1,21 @@
+####################################################################################################
+#                                      load packages
+####################################################################################################
+cd(@__DIR__)
+using Pkg
+Pkg.activate("")
+using BenchmarkPlots
+using DataFrames
+using PkgBenchmark
+using NeuralEstimators
+####################################################################################################
+#                                       benchmark
+####################################################################################################
+baselin_id = "1a4c67fb8a82076cecd25d0ba75072f3218ed354"
+baseline = benchmarkpkg(NeuralEstimators, baselin_id)
+
+target_id = "d784a53c61872319a6c6c7298fd80e3571335fde"
+target = benchmarkpkg(NeuralEstimators, target_id)
+
+comparison = judge(target, baseline)
+export_markdown("judgement_test.md", comparison)


### PR DESCRIPTION
Hello,

This PR adds benchmarks to the package (see #42). The main script can be found at /benchmark/benchmarks.jl. 

I added a benchmark for `PointEstimator`, `PosteriorEstimator`, and `RatioEstimator`. Each includes benchmarks for `train` and applicable inference methods. I also added numerous tests for each layer, which might be helpful for pin pointing problems/improvements in performance.  In some cases, I varied the size of input because that can be informative. However, I was not sure whether I varied the size of the most important inputs. Let me know if there are any gaps or any opportunities for improvement. 

Finally, I could not figure out how to run the [benchmark pr](https://github.com/itsdfish/NeuralEstimators.jl/blob/benchmarks/.github/workflows/benchmark_pr.yml) to see if it works. That might be something you need to do as the owner of the repository. 