### PR TITLE
fix benchmark_pr.toml

### DIFF
--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
-      - name: Extract Package Name from Project.toml
-        id: extract-package-name
-        run: |
-          PACKAGE_NAME=$(grep "^name" Project.toml | sed 's/^name = "\(.*\)"$/\1/')
-          echo "::set-output name=package_name::$PACKAGE_NAME"
         with:
           version: "1.11"
       - uses: julia-actions/cache@v2


### PR DESCRIPTION
I had trouble testing locally, but I modified one of my repos to ensure that the action activated the environment in `/benchmark` and loaded dependencies for the benchmark. It seemed to work, so my hope is that this change will fix the error. 