### PR TITLE
NRE and TRE updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 MLUtils = "f1d291b0-491e-4a28-83b9-f70985020b54"
@@ -31,10 +32,13 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 
 [weakdeps]
+AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GraphNeuralNetworks = "cffab07f-9bc2-4db1-8861-388f63bf7694"
+LogDensityProblems = "6fdf6af0-433a-55f7-b3ed-c6c6e0b8df7c"
 Lux = "b2108857-7c20-44ae-9111-449ecde12c47"
 LuxCore = "bb33d45b-7691-41d6-9220-0943567d0623"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -42,6 +46,7 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 
 [extensions]
+NeuralEstimatorsAdvancedHMCExt = ["AdvancedHMC", "ForwardDiff", "LogDensityProblems"]
 NeuralEstimatorsCUDAExt = "CUDA"
 NeuralEstimatorsFluxExt = "Flux"
 NeuralEstimatorsGNNExt = ["Flux", "GraphNeuralNetworks"]
@@ -51,6 +56,7 @@ NeuralEstimatorsPlottingMakieExt = ["Makie"]
 NeuralEstimatorsPlottingPlotsExt = ["Plots"]
 
 [compat]
+AdvancedHMC = "0.8"
 ADTypes = "1"
 Accessors = "0.1"
 Adapt = "4.5.0"
@@ -63,10 +69,13 @@ ConcreteStructs = "0.2.3"
 DataFrames = "1"
 Distances = "0.10, 0.11"
 Flux = "0.16.8"
+ForwardDiff = "1"
 Folds = "0.2"
 Functors = "0.5.2"
 GraphNeuralNetworks = "1"
 InvertedIndices = "1"
+KernelAbstractions = "0.9.42"
+LogDensityProblems = "2"
 Lux = "1.31"
 LuxCore = "1.5"
 MLDataDevices = "1.17.4"

--- a/ext/NeuralEstimatorsAdvancedHMCExt.jl
+++ b/ext/NeuralEstimatorsAdvancedHMCExt.jl
@@ -1,0 +1,87 @@
+# NUTS posterior sampling for the RatioEstimator.
+#
+# Design notes:
+#  * The target is log r(θ, Z) + log prior + log |J|, as a function of the
+#    UNCONSTRAINED u, with θ = lower + (upper - lower) * sigmoid(u). The sigmoid map
+#    maps to the prior box; log |J| is its Jacobian correction.
+#  * The data summaries tz are computed once per
+#    dataset Z and cached; each NUTS step then costs MLP passes (plus the ForwardDiff duals)
+#  * The chain runs in Float64 (leapfrog likes Float64); the Float32 networks promote
+#    automatically . Code can be performance tuned.
+#  * One chain per data set. NUTS trajectories are adaptive in the number of leapfrog steps,
+#    and to the best of my knowledge, there is no way to efficiently vectorize this. Recommend TRE sampling via Chebyshev approximations instead.
+
+module NeuralEstimatorsAdvancedHMCExt
+
+using NeuralEstimators
+using NeuralEstimators: RatioEstimator, summarystatistics
+using AdvancedHMC
+using ForwardDiff
+using LogDensityProblems
+
+# The box map
+_toθ(lower, upper, u) = lower .+ (upper .- lower) ./ (1 .+ exp.(-u))
+
+struct _NRELogDensity{F}
+    tz::Matrix{Float32}       # cached data summaries, one column
+    net_θ::Any                # estimator.summary_network_θ
+    net_inf::Any              # estimator.inference_network
+    lower::Vector{Float64}
+    upper::Vector{Float64}
+    logprior::F
+end
+
+LogDensityProblems.dimension(t::_NRELogDensity) = length(t.lower)
+LogDensityProblems.capabilities(::Type{<:_NRELogDensity}) = LogDensityProblems.LogDensityOrder{0}()
+
+function LogDensityProblems.logdensity(t::_NRELogDensity, u)
+    θ = _toθ(t.lower, t.upper, u)
+    # Jacobian of the sigmoid box map, written in θ: (b - a) s (1 - s) = (θ - a)(b - θ) / (b - a)
+    logJ = sum(log.((θ .- t.lower) .* (t.upper .- θ) ./ (t.upper .- t.lower)))
+    tθ = t.net_θ(reshape(θ, :, 1))
+    return only(t.net_inf(vcat(t.tz, tθ))) + t.logprior(θ) + logJ
+end
+
+function NeuralEstimators._sampleposterior_hmc(
+    estimator::RatioEstimator, Z;
+    N::Integer,
+    lower::AbstractVector,
+    upper::AbstractVector,
+    logprior::Function,
+    warmup::Integer,
+    kwargs...
+)
+    summary_stats_Z = summarystatistics(estimator, Z; kwargs...)
+    d = length(lower)
+    lo, hi = Float64.(collect(lower)), Float64.(collect(upper))
+
+    samples = map(1:size(summary_stats_Z, 2)) do k
+        t = _NRELogDensity(summary_stats_Z[:, k:k], estimator.summary_network_θ,
+                           estimator.inference_network, lo, hi, logprior)
+        u0 = zeros(d)                                  # box midpoint after the transform
+
+        # Standard AdvancedHMC: NUTS with multinomial sampling, generalised
+        # no-U-turn and Stan-style joint step-size and mass-matrix adaptation, at 100 200 and 500, should be enough unless the problem is super difficult
+        metric = DiagEuclideanMetric(d)
+        hamiltonian = Hamiltonian(metric, t, ForwardDiff)
+        integrator = Leapfrog(find_good_stepsize(hamiltonian, u0))
+        kernel = HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn()))
+        adaptor = StanHMCAdaptor(MassMatrixAdaptor(metric), StepSizeAdaptor(0.8, integrator))
+        draws, stats = AdvancedHMC.sample(hamiltonian, kernel, u0, N + warmup, adaptor, warmup;
+                                          verbose = false, progress = false)
+
+        # Keep the last N regardless of whether the installed version drops warmup draws
+        kept = draws[(end - N + 1):end]
+        keptstats = stats[(end - N + 1):end]
+        if !isempty(keptstats) && hasproperty(first(keptstats), :numerical_error)
+            ndivergent = count(s -> s.numerical_error, keptstats)
+            ndivergent > 0 && @warn "NUTS reported $ndivergent divergent transition(s) for data set $k; treat these samples with caution"
+        end
+
+        Float32.(_toθ(lo, hi, reduce(hcat, kept)))     # d × N, back on the box
+    end
+
+    return length(samples) == 1 ? samples[1] : samples
+end
+
+end

--- a/src/Chebyshev1d.jl
+++ b/src/Chebyshev1d.jl
@@ -1,0 +1,463 @@
+# Fast Chebyshev approximation, integration, and inverse-CDF sampling
+# for 1D densities. Julia port of chebyshev_utils.py from
+# https://github.com/danleonte/Simulation-based-inference-via-telescoping-ratio-estimation-for-trawl-processes-paper/blob/main/src/utils/chebyshev_utils.py
+#
+# Various Julia libraries already support efficiently approximating 1D functions, i.e. f: R -> R, by Chebyshev polynomials. 
+# This scripts targets posterior sampling for the TelescopingRatioEstimator, which requires sequentally
+# approximating batches of 1D (conditional) denisities. For efficiency, the implementation has to
+# i)  be GPU-compatible and GPU-oriented, hence non-adaptive; the degree of the approximating polynomial can not frequently change
+# ii) allow for constructing approximations in parallel, and also generated independent samples in parallel.
+#
+# It is crucial to use vectorized bisection and not gradient-based methods, which require   
+# different numbers of evaluations, thus preventing effective parallelism. By comparison,
+# ApproxFun, FastChebInterp and FastTransforms.jl are adaptive or CPU oriented, or both. 
+#
+# Design notes
+# ------------
+#  * FFT-free to keep a clean, background agnostic implementation. 
+#    The mapping from evaluated function values -> coefficients map 
+#    is given by a fixed (deg+1)x(deg+1) matrix `D` 
+#    (a DCT-I folded into a matmul); integration is a fixed
+#    (deg+2)x(deg+1) matrix `Mint`. Both are precomputed once in `ChebPlan`.
+#    This is the moral equivalent of static arguments from JAX.
+#    A note on efficiency is in order. Although FFT is O(N log N) and matrix
+#    multiplication is O(N^2), testing shows that in the intended usecase of the 
+#    TelescopingRatioEstimator, the dominant step is sampling. 
+
+#  * Sampling (inverse CDF by bisection) is ONE KernelAbstractions kernel:
+#    each thread owns one sample and runs the whole Clenshaw + bisection loop
+#    in registers. The same kernel compiles for the CPU backend (multithreaded;
+#    start Julia with `-t auto`) and for CUDA (load CUDA.jl and pass CuArrays).
+#    IMPORTANT: A previous version used a broadcast-based bisection, which on GPU was
+#    20 - 100 times slow because of unnecesarily many kernel launches. See below.
+
+#  * Dependencies: LinearAlgebra (stdlib) and KernelAbstractions
+#    (`import Pkg; Pkg.add("KernelAbstractions")`). No FFTW/CUDA dependency;
+#    CUDA support comes for free when CUDA.jl is loaded by the caller.
+# =============================================================================
+using LinearAlgebra: I
+using KernelAbstractions
+using KernelAbstractions: get_backend
+
+"""
+    chebnodes(degree, a, b)
+ 
+The `degree + 1` Chebyshev second-kind nodes `cos(jπ/deg)` on `[a, b]`, 
+ordered `j = 0, ...,  degree` from b to a.
+"""
+function chebnodes(degree::Integer, a::Real, b::Real)
+    T = float(promote_type(typeof(a), typeof(b)))
+    xstd = cos.((0:degree) .* (T(π) / degree))    # nodes in [-1, 1]
+    off = T(0.5) * (a + b)
+    scl = T(0.5) * (b - a)
+    return off .+ scl .* xstd
+end
+ 
+"""
+    chebcoeffmatrix(degree; T = Float64)
+ 
+The `(degree+1) × (degree+1)` matrix `D` mapping function values at the
+Chebyshev nodes of the second kind to first-kind Chebyshev coefficients: `c = D * fvals`.
+Domain-independent: a DCT-I with endpoint half-weights folded in.
+"""
+function chebcoeffmatrix(degree::Integer; T::Type=Float64)
+    n = degree
+    D = Matrix{T}(undef, n + 1, n + 1)
+    for k in 0:n, j in 0:n
+        qk = (k == 0 || k == n) ? one(T) : T(2)     # coefficient-index weight
+        sj = (j == 0 || j == n) ? T(0.5) : one(T)   # node-index weight
+        D[k + 1, j + 1] = (qk / n) * sj * cos(T(k * j) * (T(π) / n))
+    end
+    return D
+end
+ 
+"""
+    chebint_ab(coeff, a, b)
+ 
+Indefinite integral of a Chebyshev series on `[a, b]`: coefficients (length
+`length(coeff) + 1`) of an antiderivative, scaled by `(b - a) / 2`.
+"""
+function chebint_ab(coeff::AbstractVector{T}, a::Real, b::Real) where {T}
+    L = length(coeff)
+    out = zeros(T, L + 1)
+    scale = T((b - a) / 2)
+    out[2] = coeff[1] * scale                    # T_0 -> T_1
+    if L > 1
+        out[3] = coeff[2] * scale / 4            # T_1 -> T_2
+    end
+    @inbounds for j in 3:L                        # 0-based coeff index jj = 2 ... L-1
+        jj = j - 1
+        cj = coeff[j] * scale
+        out[jj + 2] += cj / (2 * (jj + 1))
+        out[jj]     -= cj / (2 * (jj - 1))
+    end
+    return out
+end
+ 
+"""
+    chebintmatrix(degree, a, b; T = Float64)
+ 
+The `(degree+2) × (degree+1)` matrix `Mint` with `chebint_ab(coeff, a, b) ==
+Mint * coeff`, used for the batched/GPU integration path (`Mint * C`).
+"""
+function chebintmatrix(degree::Integer, a::Real, b::Real; T::Type=Float64)
+    L = degree + 1
+    basis = Matrix{T}(I, L, L)
+    return reduce(hcat, (chebint_ab(view(basis, :, j), T(a), T(b)) for j in 1:L))
+end
+ 
+# -----------------------------------------------------------------------------
+# Evaluation (Clenshaw)
+# -----------------------------------------------------------------------------
+ 
+"""
+    chebval_ab(x, coeff, a, b)
+ 
+Evaluate the Chebyshev series resepresented by `coeff` at `x` (scalar or array) on 
+`[a, b]` via the Clenshaw recurrence, which is numerically stable and has complexity
+linear in the polynomial degree, see 
+
+https://en.wikipedia.org/wiki/Clenshaw_algorithm
+
+This function is thus suitable for one coefficient vectorr, many evaluation points.
+"""
+function chebval_ab(x, coeff::AbstractVector, a::Real, b::Real)
+    z = (2 .* x .- (a + b)) ./ (b - a)
+    L = length(coeff)
+    d = zero(z)
+    dd = zero(z)
+    @inbounds for k in L:-1:2
+        ck = coeff[k]
+        d, dd = (2 .* z .* d .- dd .+ ck), d
+    end
+    return z .* d .- dd .+ coeff[1]
+end
+ 
+# Scalar Clenshaw on one row of a pre-transposed coefficient matrix
+# `Ct :: K × L` (envelope k = row k), at the mapped coordinate `zz ∈ [-1, 1]`.
+# Plain scalar code: inlines into the KernelAbstractions kernel and compiles
+# for both CPU and GPU.
+@inline function _clenshaw_row(Ct::AbstractMatrix, k::Integer, zz)
+    L = size(Ct, 2)
+    d = zero(zz)
+    dd = zero(zz)
+    @inbounds for j in L:-1:2
+        d, dd = muladd(2 * zz, d, Ct[k, j] - dd), d
+    end
+    @inbounds return muladd(zz, d, Ct[k, 1] - dd)
+end
+ 
+"""
+    chebval_ab_batched(z, C, a, b)
+ 
+Batched Clenshaw: evaluate envelope `k` (column `C[:, k]`) at point `z[k]`.
+`z` length `K`, `C` size `(deg+1) × K`, result length `K`.
+"""
+function chebval_ab_batched(z::AbstractVector, C::AbstractMatrix, a::Real, b::Real)
+    zz = (2 .* z .- (a + b)) ./ (b - a)
+    Ct = permutedims(C)
+    d = zero(zz)
+    dd = zero(zz)
+    L = size(Ct, 2)
+    @inbounds for k in L:-1:2
+        d, dd = (2 .* zz .* d .- dd .+ @view(Ct[:, k])), d
+    end
+    return zz .* d .- dd .+ @view(Ct[:, 1])
+end
+
+"""
+    chebval_ab_batched(X::AbstractMatrix, C, a, b)
+ 
+Many points per envelope: evaluate envelope `k` (column `C[:, k]`) at the points
+`X[:, k]`. `X` size `M × K`, result `M × K`. The same Clenshaw algorithm as the
+one-point method, with the coefficient rows broadcast across the `M` points. Very importantly,
+still one broadcast per degree, not per point.
+"""
+function chebval_ab_batched(X::AbstractMatrix, C::AbstractMatrix, a::Real, b::Real)
+    size(X, 2) == size(C, 2) ||
+        throw(DimensionMismatch("one envelope per column: size(X,2)=$(size(X,2)), size(C,2)=$(size(C,2))"))
+    zz = (2 .* X .- (a + b)) ./ (b - a)
+    Ct = permutedims(C)
+    d = zero(zz)
+    dd = zero(zz)
+    L = size(Ct, 2)
+    @inbounds for k in L:-1:2
+        d, dd = (2 .* zz .* d .- dd .+ transpose(@view(Ct[:, k]))), d
+    end
+    return zz .* d .- dd .+ transpose(@view(Ct[:, 1]))
+end
+ 
+# -----------------------------------------------------------------------------
+# Inverse-CDF sampling: one fused Kernel Abstraction
+# -----------------------------------------------------------------------------
+#
+# Thread i draws sample i. `Ct :: K × L` holds antiderivative coefficients,
+# one envelope per ROW (transposed so that, at each Clenshaw step j, adjacent
+# threads read adjacent memory — coalesced on GPU; 
+
+
+#### I think numpy serializes the same way
+
+# Each envelope owns `spe`  consecutive samples 
+# (spe = length(u) ÷ K): thread i uses row (i-1) ÷ spe + 1.
+# spe = length(u) recovers the shared-envelope case, spe = 1 the one-draw-per-
+# envelope case, and anything in between is B envelopes with M draws each —
+# the mode used by the coverage checks.
+
+# --------------------------------------------------------------------------------
+# Old version with broadcasting, where latency due to launching kernels dominates.
+#
+#     function invert_cdf_batched(CI, a, b, u; iters=...)          # RETIRED
+#         Ct = permutedims(CI)
+#         lower = fill!(similar(u, T, K), T(a))
+#         upper = fill!(similar(u, T, K), T(b))
+#         lo = _chebval_cols(lower, Ct, a, b)        # Clenshaw = deg+1 broadcasts
+#         Z  = _chebval_cols(upper, Ct, a, b) .- lo
+#         for _ in 1:iters                           # 24 sequential iterations
+#             mid  = (lower .+ upper) ./ 2                       # launch
+#             Fmid = (_chebval_cols(mid, Ct, a, b) .- lo) ./ Z .- u
+#             #      deg+1 dependent broadcasts = deg+1 launches
+#             upper = ifelse.(Fmid .> 0, mid, upper)             # launch
+#             lower = ifelse.(Fmid .> 0, lower, mid)             # launch
+#         end
+#         return (lower .+ upper) ./ 2
+#     end
+# --------------------------------------------------------------------------------
+ 
+"""
+    default_bisection_iters(T)
+ 
+Interval halvings needed to reach relative machine precision
+53 for `Float64`, 24 for `Float32`. More iterations bring nothing.
+"""
+default_bisection_iters(::Type{T}) where {T} = 1 - exponent(eps(float(real(T))))
+ 
+@kernel function _invertcdf_kernel!(out, @Const(Ct), @Const(u), a, b, iters, spe)
+    i = @index(Global)
+    @inbounds if i <= length(out)
+        T = eltype(out)
+        k = (i - 1) ÷ spe + 1                      # envelope owning sample i
+        lo = _clenshaw_row(Ct, k, -one(T))         # zz(a) = -1
+        Z  = _clenshaw_row(Ct, k,  one(T)) - lo    # zz(b) = +1
+        uk = T(u[i])
+        ab = a + b
+        binv = one(T) / (b - a)
+        lower = a
+        upper = b
+        for _ in 1:iters
+            mid = (lower + upper) / 2
+            zz = muladd(T(2), mid, -ab) * binv
+            F = (_clenshaw_row(Ct, k, zz) - lo) / Z - uk   # CDF(mid) - u, nondecreasing
+            if F > zero(T)
+                upper = mid
+            else
+                lower = mid
+            end
+        end
+        out[i] = (lower + upper) / 2
+    end
+end
+ 
+
+function _invert_cdf_rows(Ct::AbstractMatrix, a::Real, b::Real, u::AbstractVector, iters::Int)
+    backend = get_backend(Ct)
+    get_backend(u) == backend ||
+        throw(ArgumentError("coefficients and uniforms must be on the same device"))
+    spe, r = divrem(length(u), size(Ct,1)) # samples for eahc envelope
+    r == 0 || throw(DimensionMismatch("length(u)=$(length(u)) must be a multiple of the number of envelopes $(size(Ct, 1))"))
+    T = float(promote_type(eltype(Ct), eltype(u)))
+    out = similar(u, T)
+    _invertcdf_kernel!(backend)(out, Ct, u, T(a), T(b), iters, spe; ndrange=length(u))
+    KernelAbstractions.synchronize(backend)
+    return out
+end
+
+########################################################################################
+############     No longer needed since the batched versions are working    ############
+########################################################################################
+###"""
+###    invert_cdf(ci, a, b, u; iters = default_bisection_iters(eltype(u)))
+###
+###Draw `length(u)` samples from ONE (unnormalised) CDF with antiderivative
+###coefficients `ci`, by bisection at the uniforms `u`. Returns samples in `[a, b]`.
+###"""
+###function invert_cdf(ci::AbstractVector, a::Real, b::Real, u::AbstractVector;
+###                    iters::Integer=default_bisection_iters(eltype(u)))
+###    return _invert_cdf_rows(reshape(ci, 1, :), a, b, u, Int(iters))
+###end
+ 
+"""
+    invert_cdf_batched(CI, a, b, u; iters = default_bisection_iters(eltype(CI)))
+ 
+Batched inverse-CDF: one envelope per column of `CI` (`(deg+2) × K`), and
+`length(u) ÷ K` uniforms per envelope. Envelope `k` owns the contiguous block
+`u[(k-1)m+1 : km]`, so `vec(U)` of an `m × K` matrix of uniforms is already in
+the right order. `length(u) == K` recovers one sample per envelope.
+"""
+function invert_cdf_batched(CI::AbstractMatrix, a::Real, b::Real, u::AbstractVector;
+                            iters::Integer=default_bisection_iters(eltype(CI)))
+    length(u) % size(CI, 2) == 0 ||
+        throw(DimensionMismatch("uniforms per envelope must be constant: size(CI,2)=$(size(CI,2)), length(u)=$(length(u))"))
+    return _invert_cdf_rows(permutedims(CI), a, b, u, Int(iters))
+end
+ 
+# -----------------------------------------------------------------------------
+# ChebPlan: precomputed operators for a fixed degree and domain
+# -----------------------------------------------------------------------------
+ 
+"""
+    ChebPlan(a, b; degree = 128, T = Float64)
+ 
+Precomputes the second-kind `nodes`, coefficient matrix `D`, and integration matrix
+`Mint` for a fixed `degree` on `[a, b]`. Build once, reuse for every envelope.
+Move to GPU by adapting the array fields to `CuArray`, e.g.
+`gpu_plan(p) = ChebPlan_on(CuArray, p)` below. This is the equivalent
+of static args from JAX in python.
+"""
+struct ChebPlan{T,MT<:AbstractMatrix{T},VT<:AbstractVector{T}}
+    degree::Int
+    a::T
+    b::T
+    nodes::VT
+    D::MT
+    Mint::MT
+end
+ 
+function ChebPlan(a::Real, b::Real; degree::Integer=128, T::Type=Float64)
+    a = T(a)
+    b = T(b)
+    nodes = collect(chebnodes(degree, a, b))::Vector{T}
+    D = chebcoeffmatrix(degree; T=T)
+    Mint = chebintmatrix(degree, a, b; T=T)
+    return ChebPlan{T,typeof(D),typeof(nodes)}(degree, a, b, nodes, D, Mint)
+end
+ 
+"""
+    ChebPlan_on(ArrayT, plan)
+ 
+Copy of `plan` with array fields converted by `ArrayT` (e.g. `CuArray`):
+`gpu_plan = ChebPlan_on(CuArray, plan)`.
+"""
+function ChebPlan_on(::Type{AT}, p::ChebPlan) where {AT}
+    nodes = AT(p.nodes)
+    D = AT(p.D)
+    Mint = AT(p.Mint)
+    return ChebPlan{eltype(D),typeof(D),typeof(nodes)}(p.degree, p.a, p.b, nodes, D, Mint)
+end
+ 
+"""
+    chebfit(plan, fvals)
+ 
+Chebyshev coefficients from values at `plan.nodes`. `fvals`: vector (single
+envelope) or `(degree+1) × K` matrix (K envelopes) — a single matmul.
+"""
+chebfit(plan::ChebPlan, fvals::AbstractVecOrMat) = plan.D * fvals
+ 
+"""
+    chebintegrate(plan, coeff)
+ 
+Antiderivative coefficients. `coeff`: vector or `(degree+1) × K` matrix.
+"""
+chebintegrate(plan::ChebPlan, coeff::AbstractVecOrMat) = plan.Mint * coeff
+
+"""
+    chebdefinite(CI, a, b)
+
+Per-envelope definite integrals over the intervall [a,b] using ANTIDERIVATIVE 
+coefficients (columnts of CI). Split out of `chebintegral` for callers that alreadyy
+hold `CI`  (e.g. because they also sample from it) and should not pay the price of
+`M_int * C` twice when it's not needed.
+"""
+function chebdefinite(CI::AbstractMatrix, a::Real, b::Real)
+    K = size(CI,2)
+    T = float(eltype(CI))
+    xb = fill!(similar(CI,T,K),T(b))
+    xa = fill!(similar(CI,T,K),T(a))
+    return chebval_ab_batched(xb,CI,a,b) .- chebval_ab_batched(xa, CI, a, b)
+    
+end
+
+ 
+"""
+    chebintegral(plan, coeff)
+ 
+Definite integral over `[plan.a, plan.b]`. Vector `coeff` → scalar; matrix
+`(deg+1) × K` → length-`K` vector of per-envelope integrals.
+"""
+function chebintegral(plan::ChebPlan, coeff::AbstractVector)
+    ci = chebintegrate(plan, coeff)
+    return chebval_ab(plan.b, ci, plan.a, plan.b) - chebval_ab(plan.a, ci, plan.a, plan.b)
+end
+
+chebintegral(plan::ChebPlan, coeff::AbstractMatrix)=
+    chebdefinite(chebintegrate(plan,coeff),plan.a,plan.b)
+
+
+"""
+    cheblogq(x, C, Zi, a, b)
+ 
+Normalised log-density of fitted polynomial densities: `log f(x) - log Zi`, with the
+value from `chebval_ab_batched(x, C, a, b)` (one point per envelope when `x` is a
+vector, many points per envelope when `x` is an `M × K` matrix) and `Zi` the
+per-envelope definite integrals, precomputed with `chebdefinite` so nothing is
+evaluated twice. Both terms are floored at `floatmin` before the log: fitted densities
+can dip slightly negative between nodes in negligible-mass tails, and the floor turns
+that into a very negative log rather than a NaN.
+
+### (dan) actually it looks like a 'DomainError', not sure if a JAX equivalent exist. 
+### docstrings can be amended later  
+
+Any positive rescaling applied to an
+envelope before fitting (e.g. a max-shift) enters value and integral alike and cancels.
+"""
+function cheblogq(x::AbstractVecOrMat, C::AbstractMatrix, Zi::AbstractVector, a::Real, b::Real)
+    T = float(promote_type(eltype(C), eltype(x)))
+    V = chebval_ab_batched(x, C, a, b)
+    Z = x isa AbstractVector ? Zi : reshape(Zi, 1, :)
+    return log.(max.(V, floatmin(T))) .- log.(max.(Z, floatmin(T)))
+end
+
+########################################################################################
+############     No longer needed since the batched versions are working    ############
+########################################################################################
+#"""
+#    chebsample(plan, fvals::AbstractVector, u; iters...)
+# 
+#Draw `length(u)` samples from the (unnormalised) density with values `fvals`
+#at `plan.nodes`. Single envelope, many samples — the coordinate-1 case.
+#"""
+#function chebsample(plan::ChebPlan, fvals::AbstractVector, u::AbstractVector;
+#                    iters::Integer=default_bisection_iters(eltype(u)))
+#    ci = chebintegrate(plan, chebfit(plan, fvals))
+#    return invert_cdf(ci, plan.a, plan.b, u; iters=iters)
+#end
+ 
+"""
+    chebsample(plan, F::AbstractMatrix, u::AbstractVector; iters...)
+ 
+Batched: one envelope per column of `F` (`(degree+1) × K`), one uniform per
+envelope, one sample per envelope — the coordinate-`i` (`i ≥ 2`) case.
+"""
+function chebsample(plan::ChebPlan, F::AbstractMatrix, u::AbstractVector;
+                    iters::Integer=default_bisection_iters(eltype(u)))
+    size(F, 2) == length(u) ||
+        throw(DimensionMismatch("one uniform per envelope: size(F,2)=$(size(F,2)), length(u)=$(length(u))"))
+    CI = chebintegrate(plan, chebfit(plan, F))
+    return invert_cdf_batched(CI, plan.a, plan.b, u; iters=iters)
+end
+
+
+"""
+    chebsample(plan, F::AbstractMatrix, U::AbstractMatrix; iters...)
+ 
+Grouped: one envelope per column of `F` (`(degree+1) × B`), `M` uniforms per
+envelope (`U` is `M × B`, column `b` for envelope `b`), returns `M × B` samples.
+The per-head coverage check case: many draws from each of many envelopes.
+"""
+function chebsample(plan::ChebPlan, F::AbstractMatrix, U::AbstractMatrix;
+                    iters::Integer=default_bisection_iters(eltype(U)))
+    size(F, 2) == size(U, 2) ||
+        throw(DimensionMismatch("one envelope per column: size(F,2)=$(size(F,2)), size(U,2)=$(size(U,2))"))
+    CI = chebintegrate(plan, chebfit(plan, F))
+    return reshape(invert_cdf_batched(CI, plan.a, plan.b, vec(U); iters=iters), size(U))
+end

--- a/src/Estimators/RatioEstimator.jl
+++ b/src/Estimators/RatioEstimator.jl
@@ -21,12 +21,14 @@ and can be used in various Bayesian
 (e.g., [Hermans et al., 2020](https://proceedings.mlr.press/v119/hermans20a.html))
 or frequentist
 (e.g., [Walchessen et al., 2024](https://doi.org/10.1016/j.spasta.2024.100848))
-inferential algorithms. For Bayesian inference, posterior samples can be obtained via simple grid-based sampling using [sampleposterior](@ref).
+inferential algorithms. For Bayesian inference, posterior samples can be obtained with [sampleposterior](@ref), either by NUTS (whcih the AdvancedHMC extension) or by 
+the simpler grid-based sampling (which is far less efficient in higher dimensions).
 
 # Keyword arguments
 - `num_summaries::Integer`: the number of summaries output by `summary_network`. Must match the output dimension of `summary_network`.
 - `num_summaries_θ::Integer = 2 * num_parameters`: the number of summaries output by the parameter summary network.
 - `summary_network_θ_kwargs::NamedTuple = (;)`: keyword arguments passed to the MLP constructor for the parameter summary network.
+- `sampler::Union{Nothing, Function} = nothing`: a function returnting `K` independent draws from the prior as a `d x K` matrix, the same as passed to [`train`](@ref). This can also be ignored, i.e., `nothing`, for backwards compatibility, see below. 
 - `kwargs...`: additional keyword arguments passed to the MLP constructor for the inference network.
 
 # Examples
@@ -44,7 +46,10 @@ num_summaries = 3d
 summary_network = Chain(Dense(m, 64, gelu), Dense(64, 64, gelu), Dense(64, num_summaries))
 
 # Initialise the estimator
-estimator = RatioEstimator(summary_network, d; num_summaries = num_summaries)
+
+estimator = RatioEstimator(summary_network, d; num_summaries = num_summaries, sampler = sampler)
+# backwards compatibility version
+# estimator = RatioEstimator(summary_network, d; num_summaries = num_summaries)
 
 # Train the estimator
 estimator = train(estimator, sampler, simulator, K = 1000)
@@ -56,6 +61,10 @@ plotrisk()
 θ_test = sampler(250)
 Z_test = simulator(θ_test);
 grid = expandgrid(0:0.01:1, 0:0.01:1)'  # fine gridding of the parameter space
+
+
+### to discuss with Matt
+
 assessment = assess(estimator, θ_test, Z_test; grid = grid)
 plot(assessment)
 
@@ -63,29 +72,45 @@ plot(assessment)
 θ = sampler(1)
 z = simulator(θ)
 
-# Grid-based evaluation and sampling
+# NUTS sampling (requires `using AdvancedHMC, ForwardDiff, LogDensityProblems`)
+sampleposterior(estimator, z; lower = [0.0, 0.0], upper = [1.0, 1.0]) # requires passing the bounds to map the domain on which we perform MCMC to unbounded
+
+
+# For backwards-compatibility: grid-based evaluation and sampling
 logratio(estimator, z; grid = grid)                # log of likelihood-to-evidence ratios
-sampleposterior(estimator, z; grid = grid)         # posterior sample
+sampleposterior(estimator, z; grid = grid)         # posterior sampling
 ```
 """
 @concrete struct RatioEstimator <: AbstractNeuralEstimator
     summary_network   # summary network for data Z (called summary_network for consistency with other estimators)
     summary_network_θ # summary network for θ 
     inference_network
+    sampler     # same sampler that generates theta, or nothing, for backwards compatibility
 end
+
+# Backwards compatibility to allow for a sampler to not be passed to the RatioEstimator class
+# there is no clash with the constructor below, where the Integer type specification differs
+RatioEstimator(summary_network, summary_network_θ, inference_network) = 
+    RatioEstimator(summary_network, summary_network_θ, inference_network, nothing)
+
+# The sampler is intentionally kept out of the network
+# e.g., to prevent silent transformations from cpu to gpu before _inputoutput invokes it
+# e.g., to not make the optimizer compute gradients w.r.t. sampler
+@functor RatioEstimator (summary_network, summary_network_θ, inference_network)
 
 # Constructor: summary network, number of parameters, number of summaries => MLP inference network
 function RatioEstimator(
     summary_network, num_parameters::Integer, num_summaries::Integer;
     num_summaries_θ::Integer = 2num_parameters,
     summary_network_θ_kwargs::NamedTuple = (;),
+    sampler::Union{Nothing,Function} = nothing,
     kwargs...
 )
     backend = _backendof(summary_network)
     summary_network_θ = MLP(num_parameters, num_summaries_θ; backend = backend, output_activation = identity, summary_network_θ_kwargs...)
     inference_network = MLP(num_summaries + num_summaries_θ, 1; backend = backend, output_activation = identity, kwargs...)
     @info "RatioEstimator: num_summaries = $num_summaries."
-    RatioEstimator(summary_network, summary_network_θ, inference_network)
+    RatioEstimator(summary_network, summary_network_θ, inference_network, sampler)
 end
 
 # Constructor: keyword num_summaries
@@ -104,8 +129,24 @@ end
 function _inputoutput(estimator::RatioEstimator, Z, θ)
 
     # Create independent pairs
+    # Ideally, these should use fresh (prior) theta draws when a sampler is available,
+    # otherwise  permutation of the already sampled parameters is used; in this case, 
+    # with probability 1 - 1/e ~= 0.63  https://math.stackexchange.com/questions/399500/why-is-the-derangement-probability-so-close-to-frac1e
+    # we mislabel at least one dependent pair as indepndent.
+    # Further, fresh theta draws lower the variance of the loss function estimators. 
+
     K = numobs(Z)
-    θ̃ = getobs(θ, shuffle(1:K))
+    θ̃ = if isnothing(estimator.sampler)
+        getobs(θ, shuffle(1:K))
+    else
+        # this is the same sampler as the one passed to train(), hence it 
+        # might return a parameter set with names and any float type;
+        # strip names below, as the data loader will handle the conversion to Float32
+        θ̃  =_stripnames(_extractθ(estimator.sampler(K)))
+        @assert size(θ̃ ) == size(θ) "sampler must generate parameters of the same dimensions as theta; 
+                                        expected $(size(θ)) got $(size(θ̃))"
+        θ̃ 
+    end
     Z̃ = Z
 
     # Combine dependent and independent pairs
@@ -180,16 +221,64 @@ function _gridlogratio(estimator::RatioEstimator, summary_stats_Z, summary_stats
     summary_stats_Z_rep = repeat(summary_stats_Z, inner = (1, G))
     summary_stats_θ_rep = repeat(summary_stats_θ, outer = (1, K))
     log_ratios = estimator.inference_network(vcat(summary_stats_Z_rep, summary_stats_θ_rep))
-    return permutedims(reshape(log_ratios, G, K))  # K × G matrix
+    return permutedims(reshape(log_ratios, G, K))  # K x G matrix
 end
 
+@doc raw"""
+	sampleposterior(estimator::RatioEstimator, Z; method = :auto, kwargs...)
+Draw `N` posterior samples for each data set in `Z`, by one of two methods:
+
+- `method = :hmc` (recommended): NUTS (via the AdvancedHMC extension) on the continuous
+  pdf that is proportional to `exp(logratio(θ) + logprior(θ))` on the box `[lower, upper]`, one
+  chain per data set with `warmup` adaptation steps discarded. Off-grid, scales to larger
+  `d`, and is the default . Caveat: any MCMC algorithm may struggle with multi-modality / challenging geometries of the posterior.
+  Requires `using AdvancedHMC, ForwardDiff, LogDensityProblems`.
+- `method = :grid`: self-normalised sampling on a fixed `grid` (a `d x G` matrix, one
+  candidate parameter configuration per column): grid atoms are drawn with replacement,
+  with weights proporional to `exp.(logprior + logratio)`. Samples live on the grid, so resolution is
+  limited by `G` and the grid size is cursed in `d, but every mode on the grid is seen.
+
+`method = :auto` (the default) resolves to `:grid` when a `grid` is supplied and to
+`:hmc` otherwise, so existing `grid`-based calls keep their previous behaviour verbatim
+while `lower`/`upper` calls get HMC.
+
+# Keyword arguments
+- `N::Integer = 1000`: number of posterior samples per data set.
+- `logprior::Function = θ -> 0f0`: log prior density evaluated on a `d`-vector, up to a constant; the default is uniform. Used by both methods. For `:hmc` it must be differentiable in the ForwardDiff sense (plain arithmetic is fine).
+- `grid`: required for `:grid`.
+- `lower`, `upper`: prior box bounds, required for `:hmc`. The chain runs in unconstrained space through a sigmoid map onto the box, with the Jacobian accounted for.
+- `warmup::Integer = 750`: adaptation steps (`:hmc` only), discarded from the output; Stan uses between 500 and 1000.
+
+# Returns
+A `d x N` matrix for a single data set, or a vector of such matrices.
+"""
 function sampleposterior(
     estimator::RatioEstimator, Z;
-    grid,
+    method::Symbol = :auto,
+    grid = nothing,
     N::Integer = 1000,
     logprior::Function = θ -> 0.0f0,
+    lower::Union{Nothing, AbstractVector} = nothing,
+    upper::Union{Nothing, AbstractVector} = nothing,
+    warmup::Integer = 750, # Stan uses between 500 and 1000; acceptance rate is 0.8 by default 
     kwargs...
 )
+    @assert method in (:auto, :grid, :hmc) "method must be :auto, :grid or :hmc"
+    if method === :auto
+        # if the user supplies the grid, we keep it that way 
+        # and importantly pre-existing `sampleposterior(estimator, Z; grid = ...)` call behaves as
+        # before, for backwards-compatibility. Otherwise default to HMC, which is the the recommended method.
+        @assert !isnothing(grid) || (!isnothing(lower) && !isnothing(upper)) "supply either `grid` (grid sampling) or `lower` and `upper` (HMC sampling)"
+        method = isnothing(grid) ? :hmc : :grid
+    end
+    if method === :hmc
+        @assert !isnothing(lower) && !isnothing(upper) "method = :hmc requires the prior box bounds `lower` and `upper`"
+        @assert length(lower) == length(upper) && all(lower .< upper) "lower bounds must be strictly below upper bounds"
+        isempty(methods(_sampleposterior_hmc)) &&
+            error("method = :hmc requires the AdvancedHMC extension: run `using AdvancedHMC, ForwardDiff, LogDensityProblems` and retry")
+        return _sampleposterior_hmc(estimator, Z; N = N, lower = lower, upper = upper, logprior = logprior, warmup = warmup, kwargs...)
+    end
+    @assert !isnothing(grid) "method = :grid requires a `grid` of candidate parameter values"
     grid = f32(grid)
 
     summary_stats = summarystatistics(estimator, Z; kwargs...)
@@ -206,6 +295,11 @@ function sampleposterior(
     return length(samples) == 1 ? samples[1] : samples
 end
 
+# Implemented by the AdvancedHMC extension (ext/NeuralEstimatorsAdvancedHMCExt.jl); no
+# methods exist unless AdvancedHMC, ForwardDiff and LogDensityProblems are loaded, which
+# the :hmc branch above checks for with a readable error.
+function _sampleposterior_hmc end
+
 # ---- Inference: Stateless (Lux) ----
 
 function logratio(estimator::RatioEstimator, Z, ps, st; grid, kwargs...)
@@ -221,7 +315,7 @@ function _gridlogratio(estimator::RatioEstimator, summary_stats_Z, summary_stats
     summary_stats_Z_rep = repeat(summary_stats_Z, inner = (1, G))
     summary_stats_θ_rep = repeat(summary_stats_θ, outer = (1, K))
     log_ratios = first(estimator.inference_network(vcat(summary_stats_Z_rep, summary_stats_θ_rep), ps_inference, st_inference))
-    return permutedims(reshape(log_ratios, G, K))  # K × G matrix
+    return permutedims(reshape(log_ratios, G, K))  # K x G matrix
 end
 
 function sampleposterior(estimator::RatioEstimator, Z, ps, st;

--- a/src/Estimators/RatioEstimator.jl
+++ b/src/Estimators/RatioEstimator.jl
@@ -21,8 +21,7 @@ and can be used in various Bayesian
 (e.g., [Hermans et al., 2020](https://proceedings.mlr.press/v119/hermans20a.html))
 or frequentist
 (e.g., [Walchessen et al., 2024](https://doi.org/10.1016/j.spasta.2024.100848))
-inferential algorithms. For Bayesian inference, posterior samples can be obtained with [sampleposterior](@ref), either by NUTS (whcih the AdvancedHMC extension) or by 
-the simpler grid-based sampling (which is far less efficient in higher dimensions).
+inferential algorithms. For Bayesian inference, posterior samples can be obtained with [sampleposterior](@ref) using the NUTS algorithm or by grid-based sampling.
 
 # Keyword arguments
 - `num_summaries::Integer`: the number of summaries output by `summary_network`. Must match the output dimension of `summary_network`.
@@ -72,13 +71,12 @@ plot(assessment)
 θ = sampler(1)
 z = simulator(θ)
 
-# NUTS sampling (requires `using AdvancedHMC, ForwardDiff, LogDensityProblems`)
-sampleposterior(estimator, z; lower = [0.0, 0.0], upper = [1.0, 1.0]) # requires passing the bounds to map the domain on which we perform MCMC to unbounded
-
-
-# For backwards-compatibility: grid-based evaluation and sampling
+# Grid-based sampling
 logratio(estimator, z; grid = grid)                # log of likelihood-to-evidence ratios
 sampleposterior(estimator, z; grid = grid)         # posterior sampling
+
+# NUTS sampling (requires `using AdvancedHMC, ForwardDiff, LogDensityProblems`)
+sampleposterior(estimator, z; lower = [0.0, 0.0], upper = [1.0, 1.0]) # requires passing the parameter bounds
 ```
 """
 @concrete struct RatioEstimator <: AbstractNeuralEstimator

--- a/src/Estimators/RatioEstimator.jl
+++ b/src/Estimators/RatioEstimator.jl
@@ -56,17 +56,6 @@ estimator = train(estimator, sampler, simulator, K = 1000)
 # Plot the risk history
 plotrisk()
 
-# Assess the estimator
-θ_test = sampler(250)
-Z_test = simulator(θ_test);
-grid = expandgrid(0:0.01:1, 0:0.01:1)'  # fine gridding of the parameter space
-
-
-### to discuss with Matt
-
-assessment = assess(estimator, θ_test, Z_test; grid = grid)
-plot(assessment)
-
 # Generate "observed" data 
 θ = sampler(1)
 z = simulator(θ)
@@ -130,7 +119,7 @@ function _inputoutput(estimator::RatioEstimator, Z, θ)
     # Ideally, these should use fresh (prior) theta draws when a sampler is available,
     # otherwise  permutation of the already sampled parameters is used; in this case, 
     # with probability 1 - 1/e ~= 0.63  https://math.stackexchange.com/questions/399500/why-is-the-derangement-probability-so-close-to-frac1e
-    # we mislabel at least one dependent pair as indepndent.
+    # we mislabel at least one dependent pair as independent.
     # Further, fresh theta draws lower the variance of the loss function estimators. 
 
     K = numobs(Z)
@@ -141,8 +130,7 @@ function _inputoutput(estimator::RatioEstimator, Z, θ)
         # might return a parameter set with names and any float type;
         # strip names below, as the data loader will handle the conversion to Float32
         θ̃  =_stripnames(_extractθ(estimator.sampler(K)))
-        @assert size(θ̃ ) == size(θ) "sampler must generate parameters of the same dimensions as theta; 
-                                        expected $(size(θ)) got $(size(θ̃))"
+        @assert size(θ̃ ) == size(θ) "sampler must generate parameters of the same dimensions as theta; expected $(size(θ)) got $(size(θ̃))"
         θ̃ 
     end
     Z̃ = Z

--- a/src/Estimators/TelescopingRatioEstimator.jl
+++ b/src/Estimators/TelescopingRatioEstimator.jl
@@ -1,0 +1,477 @@
+@doc raw"""
+	TelescopingRatioEstimator <: AbstractNeuralEstimator
+	TelescopingRatioEstimator(summary_network, num_parameters; num_summaries, sampler, kwargs...)
+A neural estimator that factorises the likelihood-to-evidence ratio sequentally accross parameter diemsnions, with
+one classifier MLP head per parameter coordinate. Currently, the implementation only supports the case in which
+the prior factorizes p(\boldsymbol{\theta}) = \prod_{i=1}^d p(\theta^i). In this case, we have that
+```math
+r(\boldsymbol{Z}, \boldsymbol{\theta}) = \prod_{i=1}^{d} r_i(\boldsymbol{Z}, \theta_i \mid \theta_1, \dots, \theta_{i-1}),
+```
+and head $i$ discriminates the true $\theta_i$ from a fresh prior draw, holding the
+prefix $\theta_1, \dots, \theta_{i-1}$ fixed and conditioning on it. Summing the per-head
+log-ratios recovers the joint log-ratio estimated by [`RatioEstimator`](@ref), but the
+factorisation also exposes each one-dimensional conditional
+$p(\theta_i \mid \theta_1, \dots, \theta_{i-1}, \boldsymbol{Z})$ individually, which allows for efficient posterior sampling via
+approximate Chebyshev polynomial fitting.
+
+Indeed, [`sampleposterior`](@ref) draws $\theta_1 \mid \boldsymbol{Z}$, then $\theta_2 \mid \theta_1, \boldsymbol{Z}$, 
+and so on, approximating each conditional with a Chebyshev polynomial and inverting its CDF exactly.
+No MCMC, no grid, and the cost grows linearly rather than exponentially in $d$.
+
+The data are summarised by `summary_network`; the heads are a `MultiHeadMLP` with growing
+inputs, head $i$ taking the summaries together with $\theta_1, \dots, \theta_i$.
+
+# Keyword arguments
+- `num_summaries::Integer`: the number of summaries output by `summary_network`. Must match the output dimension of `summary_network`.
+- `sampler::Function`: a function returning `K` independent draws from the prior as a `d × K` matrix, the same function passed as `sampler` to [`train`](@ref). Required: the independent pairs of each head are formed from fresh prior draws of the focus coordinate.
+- `kwargs...`: additional keyword arguments passed to the `MultiHeadMLP` constructor for the heads.
+
+# Examples
+```julia
+using NeuralEstimators, Flux
+
+# Data Z|μ,σ ~ N(μ, σ²) with priors μ ~ U(0, 1) and σ ~ U(0, 1)
+d, m = 2, 10  # dimension of θ and number of replicates
+sampler(K) = NamedMatrix(μ = rand(K), σ = rand(K))
+simulator(θ::AbstractVector) = θ["μ"] .+ θ["σ"] .* sort(randn(m))
+simulator(θ::AbstractMatrix) = reduce(hcat, map(simulator, eachcol(θ)))
+
+# Neural network
+num_summaries = 3d
+summary_network = Chain(Dense(m, 32, gelu), Dense(32, 16, gelu), Dense(16, num_summaries))
+
+# Initialise the estimator
+estimator = TelescopingRatioEstimator(summary_network, d; num_summaries = num_summaries, sampler = sampler)
+
+# Train the estimator
+estimator = train(estimator, sampler, simulator, K = 10000)
+
+# Generate "observed" data
+θ = sampler(1)
+z = simulator(θ)
+
+# Evaluation and sequential posterior sampling
+grid = expandgrid(0:0.01:1, 0:0.01:1)'  # evaluation points for the log-ratio
+logratio(estimator, z; grid = grid)     # log of likelihood-to-evidence ratios
+logposterior(estimator, grid, z; lower = [0.0, 0.0], upper = [1.0, 1.0])  # log posterior density
+sampleposterior(estimator, z; lower = [0.0, 0.0], upper = [1.0, 1.0])     # posterior sample
+```
+"""
+@concrete struct TelescopingRatioEstimator <: AbstractNeuralEstimator
+    summary_network # summary network for data Z (called summary_network for consistency with other estimators)
+    heads           # MultiHeadMLP with growing inputs; head i takes the summaries and the first i coordinates θ1,..., θi of θ
+    sampler         # same sampler that generates theta
+end
+ 
+# The sampler is intentionally kept out of the network, same as in RatioEstimator.jl
+# e.g., to prevent silent transformations from cpu to gpu before _inputoutput invokes it
+# e.g., to not make the optimizer compute gradients w.r.t. sampler
+@functor TelescopingRatioEstimator (summary_network, heads)
+ 
+# Constructor: summary network, number of parameters, number of summaries => one classifier head per parameter
+function TelescopingRatioEstimator(
+    summary_network, num_parameters::Integer, num_summaries::Integer;
+    sampler::Function,
+    kwargs...
+)
+    backend = _backendof(summary_network)
+    heads = MultiHeadMLP(num_summaries, 1, num_parameters; backend = backend, growing = true, output_activation = identity, kwargs...)
+    @info "TelescopingRatioEstimator: num_summaries = $num_summaries, num_heads = $num_parameters."
+    TelescopingRatioEstimator(summary_network, heads, sampler)
+end
+ 
+# Constructor: keyword num_summaries
+TelescopingRatioEstimator(summary_network, num_parameters::Integer; num_summaries::Integer, kwargs...) = TelescopingRatioEstimator(summary_network, num_parameters, num_summaries; kwargs...)
+ 
+# Number of heads (= number of parameters); both Flux and Lux store the branches of Parallel in `layers`; 
+_numheads(estimator::TelescopingRatioEstimator) = length(estimator.heads.layers)
+ 
+# Evaluate a single head, without running the other heads through Parallel, which would be wastfeul, particularly when
+# Used by the sequential posterior sampler, which needs head i alone at many synthetic inputs.
+# Flux stores the branches in a Tuple, Lux in a NamedTuple; ps/st mirror the NamedTuple order,
+# positional indexing lines up across all three.
+# to double check with Matt around here, and also flag the summary statsitics being transafered to CPU;
+# we have the kernel abstraction that works faster on GPU
+# important becaues it gives speed of sampling close to normalizing flows
+_head(estimator::TelescopingRatioEstimator, i::Integer, X) = estimator.heads.layers[i](X)
+_head(estimator::TelescopingRatioEstimator, i::Integer, X, ps, st) = first(estimator.heads.layers[i](X, ps.heads[i], st.heads[i]))
+ 
+function _inputoutput(estimator::TelescopingRatioEstimator, Z, θ)
+    d, K = size(θ)
+    @assert d == _numheads(estimator) "θ has $d rows but the estimator has $(_numheads(estimator)) heads"
+ 
+    # Fresh prior draws: row i provides the focus coordinate of head i's independent pairs
+    θ̃ = _stripnames(_extractθ(estimator.sampler(K)))
+    @assert size(θ̃) == (d, K) "sampler(K) must return a $d × $K parameter matrix; got $(size(θ̃))"
+ 
+    # Binary class labels: rows 1:d for the dependent pairs, rows d+1:2d for the independent pairs.
+    # Positives and negatives are stacked along rows (not columns) so that all components of the
+    # input share numobs = K, as required by the data loader; this also keeps each (Z, θ, θ̃)
+    # aligned under shuffling, which is importntt bc independent pairs reuse the
+    # parameter prefix (i.e. first coodinates) of their dependent prefix.
+    output = vcat(ones(Float32, d, K), zeros(Float32, d, K))
+ 
+    input = (Z, θ, θ̃)
+    return input, output
+end
+ 
+_loss(estimator::TelescopingRatioEstimator, loss = nothing) = logitbinarycrossentropy
+
+# Let θ1,...,θd, Z be the data. Head i is a classifier that inputs the data summaries,
+# the prefix θ1,...,θi-1 which it hold fixed, and a new value for θi
+# this last value is either the true one θi (label 1), or a fresh draw from the prior (label = 0).
+# NB: map |> Tuple rather than ntuple: Zygote has no rule for ntuple, whose Base implementation
+#     switches from unrolled tuples to a generator for n > 10; map over a range is reliably
+#     differentiable for any number of heads
+_headinputs(tz, θ) = map(i -> vcat(tz, θ[1:i, :]), 1:size(θ, 1)) |> Tuple
+_headinputs(tz, θ, θ̃) = map(i -> vcat(tz, θ[1:(i - 1), :], θ̃[i:i, :]), 1:size(θ, 1)) |> Tuple
+ 
+# Forward pass: Stateful (Flux)
+# Returns the d × K matrix of per-head logits; the total log-ratio is the sum over rows
+function (estimator::TelescopingRatioEstimator)(Z, θ)
+    tz = _summarystatistics(estimator, Z)
+    estimator.heads(_headinputs(tz, θ))
+end
+ 
+# Training forward pass: 2d × K logits, matching the labels constructed in _inputoutput
+function (estimator::TelescopingRatioEstimator)(Z, θ, θ̃)
+    tz = _summarystatistics(estimator, Z)
+    pos = estimator.heads(_headinputs(tz, θ))
+    neg = estimator.heads(_headinputs(tz, θ, θ̃))
+    vcat(pos, neg)
+end
+ 
+# Forward pass: Stateless (Lux)
+function (e::TelescopingRatioEstimator)(Z, θ, ps, st)
+    tz, st_s = _summarystatistics(e, Z, ps.summary_network, st.summary_network)
+    tz = tz |> copy # materialise to break Enzyme's trace (see the note in RatioEstimator.jl) # to check with Matt
+    logits, st_h = e.heads(_headinputs(tz, θ), ps.heads, st.heads)
+    return logits, (summary_network = st_s, heads = st_h)
+end
+ 
+function (e::TelescopingRatioEstimator)(Z, θ, θ̃, ps, st)
+    tz, st_s = _summarystatistics(e, Z, ps.summary_network, st.summary_network)
+    tz = tz |> copy # materialise to break Enzyme's trace (see the note in RatioEstimator.jl) # to check with Matt
+    pos, st_h = e.heads(_headinputs(tz, θ), ps.heads, st.heads)
+    neg, st_h = e.heads(_headinputs(tz, θ, θ̃), ps.heads, st_h)
+    return vcat(pos, neg), (summary_network = st_s, heads = st_h)
+end
+ 
+# Tuple methods used internally during training
+# bridge between the generic training loop and the TRE's specific forward-pass
+(estimator::TelescopingRatioEstimator)(input::Tuple) = estimator(input...)
+(estimator::TelescopingRatioEstimator)(input::Tuple, ps, st) = estimator(input..., ps, st)
+ 
+# ---- Inference: Stateful (Flux) ----
+ 
+function logratio(estimator::TelescopingRatioEstimator, Z; grid, kwargs...)
+    grid = f32(grid)
+    summary_stats_Z = summarystatistics(estimator, Z; kwargs...)
+    _gridlogratio(estimator, summary_stats_Z, grid)
+end
+ 
+function _gridlogratio(estimator::TelescopingRatioEstimator, summary_stats_Z, grid::AbstractMatrix)
+    K = size(summary_stats_Z, 2)    # number of data sets
+    G = size(grid, 2)               # number of grid points
+    # Repeat so that the summaries and the grid both have GxK columns
+    summary_stats_Z_rep = repeat(summary_stats_Z, inner = (1, G))
+    grid_rep = repeat(grid, outer = (1, K))
+    logits = estimator.heads(_headinputs(summary_stats_Z_rep, grid_rep))
+    log_ratios = sum(logits, dims = 1)  # total log-ratio: sum of the per-head conditional log-ratios
+    return permutedims(reshape(log_ratios, G, K))  # K × G matrix
+end
+ 
+@doc raw"""
+	sampleposterior(estimator::TelescopingRatioEstimator, Z; lower, upper, N = 1000, batchsize = 1, kwargs...)
+Draw posterior samples sequentially in the coordinate of theta: first generate 
+$\theta_1 \mid Z$ from head 1, then $\theta_2 \mid \theta_1, Z$ from head 2, and so on
+up to head number d. Each one-dimensional conditional density is approximated by a 
+Chebyshev polynomial of the given `degree` on `[lower[i], upper[i]]` and sampled exactly 
+through its inverse CDF, where exact means up to machine precision. Specifically, the sampling from
+the Chebyshev approximation is exact to machine-precision, not the approximation itself. The latter
+is harder to guarantee, although these approximations have excellent convergence properties, e.g.,
+super-polynomial if the activation functions are analytic.
+ 
+The first coordinate uses a single envelope for all `N` samples; every other coordinate
+must build one envelope per sample, because each sample has a different prefix;
+the procedure is fitted and inverted in a single batched pass for efficiency.
+ 
+# Keyword arguments
+- `lower::AbstractVector`, `upper::AbstractVector`: prior bounds for each of the `d` parameter coordinates. Samples are drawn from the posterior restricted to this box, which is exact when the prior is supported on it.
+- `N::Integer = 1000`: number of posterior samples.
+- `degree::Integer = 128`: degree of the Chebyshev approximation of each conditional density.
+- `logpriors = nothing`: `nothing` assumes the prior is uniform over the box (the typical case, and the density weight then cancels exactly); otherwise, a vector of `d` functions where `logpriors[i]` is the log marginal prior density of the `i`-th coordinate. This must agree with the marginals of the `sampler` used during training, otherwise samples are drawn from the wrong distribution.
+- `batchsize::Integer = 1`: number of data sets fused together (per coordinate) for efficiency, essentially like a batch. Defaults to 1; raising the value substantially improves computational efficiency when multiple data sets are available, at the cost of using more memory — out-of-memory errors are possible with large values.
+"""
+function sampleposterior(
+    estimator::TelescopingRatioEstimator, Z;
+    lower::AbstractVector,
+    upper::AbstractVector,
+    N::Integer = 1000,
+    degree::Integer = 128,
+    logpriors::Union{Nothing, AbstractVector} = nothing,
+    batchsize::Integer = 1,
+    kwargs...
+)
+    summary_stats_Z = summarystatistics(estimator, Z; kwargs...)
+    headfun = (i, X) -> _head(estimator, i, X)
+    _sampleposterior_blocks(estimator, headfun, summary_stats_Z, lower, upper, N, degree, logpriors, batchsize)
+end
+ 
+# Chunk the data sets and run each block through the fused core. batchsize = 1 defaults to
+# processing the data sets in a one-at-a-time fashion.
+function _sampleposterior_blocks(estimator::TelescopingRatioEstimator, headfun, summary_stats_Z, lower, upper, N::Integer, degree::Integer, logpriors, batchsize::Integer)
+    K = size(summary_stats_Z, 2)
+    samples = Vector{Matrix{eltype(summary_stats_Z)}}(undef, K)
+    for block in Iterators.partition(1:K, batchsize)
+        θdrawn, _, _ = _sequential_core(estimator, headfun, summary_stats_Z[:, block], lower, upper, N, nothing, degree, logpriors)
+        for (j, k) in enumerate(block)
+            samples[k] = θdrawn[:, ((j - 1) * N + 1):(j * N)]
+        end
+    end
+    return K == 1 ? samples[1] : samples
+end
+ 
+# Backend-agnostic sequential core shared by sampleposterior, logposterior, and the
+# coverage checks in calibration.jl; `headfun(i, X)` evaluates head i on the input
+# matrix X and returns a 1 × size(X, 2) matrix of logits. All cheb envelope conventions
+# live here and nowhere else: node ordering, prefix-major column layout, max-shift.
+#
+# Processes a block of B data sets (columns of tzs) in one fused pass, for improved efficiency. Per data set
+# there are N drawn columns and F fixed columns:
+#   * drawn columns are posterior draws, sampled coordinate by coordinate;
+#   * fixed columns are never sampled; their coordinates are given by θfixed (d × F*B,
+#     data-set-major) and only their log-density under the sampling law is accumulated.
+# logposterior is the N = 0 case; plain sampling is F = 0; the joint coverage check
+# uses N = M draws plus F = 1 (the true parameter).
+#
+# Global column layout, drawn block then fixed block, both data-set-major:
+#     [ds1 draws ... dsB draws | ds1 fixed ... dsB fixed]
+# so envelopes, head inputs, uniforms and outputs all reshape consistently.
+#
+# With logq = true, log-densities are accumulated from the same fitted
+# polynomial the samples are drawn from: log chebval - log chebdefinite per coordinate.
+# The max-shift inside _chebdensity cancels between the value and the integral, and a
+# non-uniform logpriors enters both, so the result is exactly the (normalised)
+# log-density of the sampling law (floors and cancellation: see cheblogq).
+function _sequential_core(estimator::TelescopingRatioEstimator, headfun, tzs, lower, upper, N::Integer, θfixed, degree::Integer, logpriors; logq::Bool = false)
+    d = _numheads(estimator)
+    @assert length(lower) == d && length(upper) == d "lower and upper must have one entry per parameter; expected length $d"
+    @assert all(lower .< upper) "lower bounds must be strictly below upper bounds"
+    isnothing(logpriors) || @assert length(logpriors) == d "logpriors must have one entry per parameter; expected length $d"
+ 
+    # Match the network's element type (typically Float32) throughout: the Chebyshev plans,
+    # the node inputs, and the uniforms. Mixing in Float64 anywhere silently promotes the
+    # whole pipeline.
+    T = eltype(tzs)
+    L = degree + 1
+    B = size(tzs, 2)
+ 
+    # Fixed columns may lie outside the box (logposterior at arbitrary points): clamp
+    # them for the polynomial work, remember which, and overwrite with -Inf at the end
+    # (zero density under the truncated sampling law).
+    F = 0
+    θf = nothing
+    inbox = nothing
+    if !isnothing(θfixed)
+        θf = T.(_stripnames(_extractθ(θfixed)))
+        @assert size(θf, 1) == d "θfixed must have one row per parameter; expected $d rows, got $(size(θf, 1))"
+        @assert size(θf, 2) % B == 0 "θfixed must hold the same number of fixed columns for each of the $B data sets"
+        F = size(θf, 2) ÷ B
+        lo, hi = T.(collect(lower)), T.(collect(upper))
+        inbox = vec(all((θf .>= lo) .& (θf .<= hi), dims = 1))
+        θf = clamp.(θf, lo, hi)
+    end
+    @assert N > 0 || F > 0 "nothing to do: no drawn and no fixed columns"
+ 
+    θdrawn = Matrix{T}(undef, d, N * B)
+    lq_drawn = logq && N > 0 ? zeros(T, N * B) : nothing
+    lq_fixed = logq && F > 0 ? zeros(T, F * B) : nothing
+ 
+    for i in 1:d
+        plan = ChebPlan(lower[i], upper[i]; degree = degree, T = T)
+        # NB: plan.nodes runs from upper[i] down to lower[i]; chebfit assumes function
+        #     values in exactly that order, so evaluate the head at plan.nodes verbatim
+        #     and never reorder
+        nodesrow = reshape(plan.nodes, 1, L)
+        logp = isnothing(logpriors) ? nothing : T.(logpriors[i].(plan.nodes))
+        if i == 1
+            # One envelope per data set, shared by all of its drawn and fixed columns
+            X = vcat(repeat(tzs, inner = (1, L)), repeat(nodesrow, 1, B))
+            Fv = _chebdensity(reshape(vec(headfun(1, X)), L, B), logp)
+            C = chebfit(plan, Fv)
+            CI = chebintegrate(plan, C)
+            if N > 0
+                # B envelopes, N draws each; vec of an N × B uniform matrix groups each
+                # envelope's draws contiguously, as invert_cdf_batched expects
+                θdrawn[1, :] = invert_cdf_batched(CI, plan.a, plan.b, vec(rand(T, N, B)))
+            end
+            if logq
+                Zi = chebdefinite(CI, plan.a, plan.b)
+                N > 0 && (lq_drawn .+= vec(cheblogq(reshape(θdrawn[1, :], N, B), C, Zi, plan.a, plan.b)))
+                F > 0 && (lq_fixed .+= vec(cheblogq(reshape(θf[1, :], F, B), C, Zi, plan.a, plan.b)))
+            end
+        else
+            # One envelope per column, each defined by that column's prefix. Columns are
+            # ordered prefix-major, nodes-minor, so that reshaping the head output to
+            # L × (N*B + F*B) puts envelope n in column n with values at plan.nodes,
+            # which is the layout chebfit expects. Drawn and fixed envelopes share one
+            # head call.
+            Xd = N > 0 ? vcat(repeat(tzs, inner = (1, N * L)), repeat(view(θdrawn, 1:(i - 1), :), inner = (1, L)), repeat(nodesrow, 1, N * B)) : nothing
+            Xf = F > 0 ? vcat(repeat(tzs, inner = (1, F * L)), repeat(view(θf, 1:(i - 1), :), inner = (1, L)), repeat(nodesrow, 1, F * B)) : nothing
+            X = N > 0 ? (F > 0 ? hcat(Xd, Xf) : Xd) : Xf
+            Fv = _chebdensity(reshape(vec(headfun(i, X)), L, N * B + F * B), logp)
+            C = chebfit(plan, Fv)
+            CI = chebintegrate(plan, C)
+            if N > 0
+                # one uniform per drawn envelope, one draw each
+                θdrawn[i, :] = invert_cdf_batched(view(CI, :, 1:(N * B)), plan.a, plan.b, rand(T, N * B))
+            end
+            if logq
+                Zi = chebdefinite(CI, plan.a, plan.b)
+                N > 0 && (lq_drawn .+= cheblogq(θdrawn[i, :], view(C, :, 1:(N * B)), view(Zi, 1:(N * B)), plan.a, plan.b))
+                F > 0 && (lq_fixed .+= cheblogq(θf[i, :], view(C, :, (N * B + 1):(N * B + F * B)), view(Zi, (N * B + 1):(N * B + F * B)), plan.a, plan.b))
+            end
+        end
+    end
+ 
+    isnothing(lq_fixed) || (lq_fixed[.!inbox] .= T(-Inf))
+    return θdrawn, lq_drawn, lq_fixed
+end
+ 
+# Unnormalised density values at the Chebyshev nodes from per-head logits, optionally
+# weighted by the log marginal prior density at the nodes. The per-envelope maximum is
+# subtracted before exponentiating to prevent overflow for concentrated posteriors;
+# the shift cancels when the CDF is normalised inside the sampler, and likewise between
+# the value and the integral in the log-density accumulation of _sequential_core.
+function _chebdensity(logits::AbstractVecOrMat, logp)
+    s = isnothing(logp) ? logits : logits .+ logp
+    exp.(s .- maximum(s, dims = 1))
+end
+ 
+@doc raw"""
+	logposterior(estimator::TelescopingRatioEstimator, θpoints, Z; lower, upper, method = :raw, kwargs...)
+Log-density of the approximate posterior at each parameter configuration in `θpoints`
+(a `d × M` matrix, one configuration per column), by one of two methods that are NOT
+interchangeable:
+
+- `method = :raw` (default): the summed head logits plus the log prior — one network
+  pass per head over the `M` points, no Chebyshev machinery. UNNORMALISED: defined up
+  to an additive per-data-set constant. The right choice for MAP search, MCMC, or any
+  within-data-set comparison that only needs the density up to a constant.
+- `method = :chebyshev`: the normalised log-density of the law that
+  [`sampleposterior`](@ref) actually draws from — per coordinate, the same envelope is
+  fitted (deterministically, given the parameter prefix) and its value and normalising
+  integral are read off the same polynomial. Roughly `degree + 1` times the network
+  cost of `:raw`. Required whenever draws and query points must be ranked under the
+  sampled law; the coverage checks pin this method internally.
+
+The two outputs differ by the θ-dependent product of the prefix normalising constants,
+not by a constant, so never mix methods within one computation; they agree (up to a
+per-data-set constant) only in the limit of perfectly self-normalised heads. Both
+report `-Inf` outside the box, the support of the (truncated) sampling law.
+
+# Keyword arguments
+`lower` and `upper` (required); `logpriors = nothing` as in [`sampleposterior`](@ref),
+used by both methods; `degree = 128` (`:chebyshev` only). For self-consistency with
+draws, `:chebyshev` must be called with the same `degree` and `logpriors` used when
+sampling.
+
+# Returns
+A length-`M` vector of log-densities (one per column of `θpoints`) for a single data
+set, or a vector of such vectors when `Z` contains multiple data sets.
+"""
+function logposterior(
+    estimator::TelescopingRatioEstimator, θpoints::AbstractMatrix, Z;
+    lower::AbstractVector,
+    upper::AbstractVector,
+    method::Symbol = :raw,
+    degree::Integer = 128,
+    logpriors::Union{Nothing, AbstractVector} = nothing,
+    kwargs...
+)
+    @assert method in (:raw, :chebyshev) "method must be :raw or :chebyshev"
+    if method === :raw
+        return _logposterior_raw(logratio(estimator, Z; grid = θpoints, kwargs...), θpoints, lower, upper, logpriors)
+    end
+    summary_stats_Z = summarystatistics(estimator, Z; kwargs...)
+    headfun = (i, X) -> _head(estimator, i, X)
+    _logposterior_blocks(estimator, headfun, summary_stats_Z, θpoints, lower, upper, degree, logpriors)
+end
+ 
+# Raw path: one row of logratio per data set (summed head logits at the query points),
+# plus the log prior, -Inf outside the box. Unnormalised, and relative to :chebyshev
+# the prefix-dependent normalisers are absorbed into the shape — see the docstring.
+function _logposterior_raw(LR::AbstractMatrix, θpoints, lower, upper, logpriors)
+    θ = _stripnames(_extractθ(θpoints))
+    @assert size(θ, 1) == length(lower) && length(lower) == length(upper) "θpoints must have one row per parameter"
+    T = eltype(LR)
+    lp = isnothing(logpriors) ? zeros(T, size(θ, 2)) : sum(i -> T.(logpriors[i].(θ[i, :])), 1:size(θ, 1))
+    inbox = vec(all((θ .>= lower) .& (θ .<= upper), dims = 1))
+    results = map(1:size(LR, 1)) do k
+        v = vec(LR[k, :]) .+ lp
+        v[.!inbox] .= T(-Inf)
+        v
+    end
+    return length(results) == 1 ? results[1] : results
+end
+ 
+# Same points evaluated for every data set; one core call per data set (N = 0, all
+# columns fixed). No fusing across data sets here: the joint coverage check, where the
+# workload is real, has its own fused path through _sequential_core.
+function _logposterior_blocks(estimator::TelescopingRatioEstimator, headfun, summary_stats_Z, θpoints, lower, upper, degree::Integer, logpriors)
+    results = map(1:size(summary_stats_Z, 2)) do k
+        _, _, lq = _sequential_core(estimator, headfun, summary_stats_Z[:, k:k], lower, upper, 0, θpoints, degree, logpriors; logq = true)
+        lq
+    end
+    return length(results) == 1 ? results[1] : results
+end
+ 
+# ---- Inference: Stateless (Lux) ----
+ 
+function logratio(estimator::TelescopingRatioEstimator, Z, ps, st; grid, kwargs...)
+    grid = f32(grid)
+    summary_stats_Z = summarystatistics(estimator, Z, ps, st; kwargs...)
+    _gridlogratio(estimator, summary_stats_Z, grid, ps.heads, st.heads)
+end
+ 
+function _gridlogratio(estimator::TelescopingRatioEstimator, summary_stats_Z, grid::AbstractMatrix, ps_heads, st_heads)
+    K = size(summary_stats_Z, 2)
+    G = size(grid, 2)
+    summary_stats_Z_rep = repeat(summary_stats_Z, inner = (1, G))
+    grid_rep = repeat(grid, outer = (1, K))
+    logits = first(estimator.heads(_headinputs(summary_stats_Z_rep, grid_rep), ps_heads, st_heads))
+    log_ratios = sum(logits, dims = 1)
+    return permutedims(reshape(log_ratios, G, K))  # K × G matrix
+end
+ 
+function sampleposterior(estimator::TelescopingRatioEstimator, Z, ps, st;
+    lower::AbstractVector,
+    upper::AbstractVector,
+    N::Integer = 1000,
+    degree::Integer = 128,
+    logpriors::Union{Nothing, AbstractVector} = nothing,
+    batchsize::Integer = 1,
+    kwargs...
+)
+    summary_stats_Z = summarystatistics(estimator, Z, ps, st; kwargs...)
+    headfun = (i, X) -> _head(estimator, i, X, ps, st)
+    _sampleposterior_blocks(estimator, headfun, summary_stats_Z, lower, upper, N, degree, logpriors, batchsize)
+end
+ 
+function logposterior(estimator::TelescopingRatioEstimator, θpoints::AbstractMatrix, Z, ps, st;
+    lower::AbstractVector,
+    upper::AbstractVector,
+    method::Symbol = :raw,
+    degree::Integer = 128,
+    logpriors::Union{Nothing, AbstractVector} = nothing,
+    kwargs...
+)
+    @assert method in (:raw, :chebyshev) "method must be :raw or :chebyshev"
+    if method === :raw
+        return _logposterior_raw(logratio(estimator, Z, ps, st; grid = θpoints, kwargs...), θpoints, lower, upper, logpriors)
+    end
+    summary_stats_Z = summarystatistics(estimator, Z, ps, st; kwargs...)
+    headfun = (i, X) -> _head(estimator, i, X, ps, st)
+    _logposterior_blocks(estimator, headfun, summary_stats_Z, θpoints, lower, upper, degree, logpriors)
+end

--- a/src/NeuralEstimators.jl
+++ b/src/NeuralEstimators.jl
@@ -57,8 +57,13 @@ for file in sort(readdir(joinpath(@__DIR__, "ApproximateDistributions")))
     include(joinpath("ApproximateDistributions", file))
 end
 
+# Batched Chebyshev machinery for 1D density fitting and inverse-CDF sampling,
+# used by the TelescopingRatioEstimator's sequential posterior sampler
+include("Chebyshev1d.jl")
+# i think we don't need to make anything in this script visible
+
 export AbstractNeuralEstimator, AbstractBayesEstimator
-export PosteriorEstimator, RatioEstimator, PointEstimator, IntervalEstimator, QuantileEstimator
+export PosteriorEstimator, RatioEstimator, TelescopingRatioEstimator, PointEstimator, IntervalEstimator, QuantileEstimator
 export Ensemble, PiecewiseEstimator
 export LuxEstimator
 export summarynetwork, setsummarynetwork, summarystatistics
@@ -81,7 +86,7 @@ include("TrainState.jl")
 export assess, Assessment, merge, join, risk, bias, rmse, coverage, intervalscore, empiricalprob
 include("assess.jl")
 
-export estimate, sampleposterior, spikeprobability, logratio, posteriormean, posteriormedian, posteriorquantile, bootstrap, interval, quantiles
+export estimate, sampleposterior, logposterior, spikeprobability, logratio, posteriormean, posteriormedian, posteriorquantile, bootstrap, interval, quantiles
 include("inference.jl")
 
 export stackarrays, expandgrid, numberreplicates, samplesize, drop, containertype, rowwisenorm, subsetreplicates

--- a/src/assess.jl
+++ b/src/assess.jl
@@ -189,7 +189,7 @@ end
 
 # Posterior sampling 
 function assess(
-    estimator::Union{PosteriorEstimator, RatioEstimator}, θ, Z, args...;
+    estimator::Union{PosteriorEstimator, RatioEstimator, TelescopingRatioEstimator}, θ, Z, args...;    
     parameter_names::Vector{String} = ["θ$i" for i ∈ 1:size(θ, 1)],
     estimator_name::Union{Nothing, String} = nothing,
     estimator_names::Union{Nothing, String} = nothing,


### PR DESCRIPTION
- Amend the NRE implementation to avoid samples from class Y = 1 being labeled as Y=0; this change requires the prior sampler to be passed, and it backwards compatible 
- Add posterior sampling by NUTS for NRE
- Add an implementation of the TRE, with fast approximate posterior sampling using Chebyshev polynomials. This introduces a second layer of approximations on top of the neural network approximation itself, but it is typically negligible for practical purposes. The kernel abstraction implementation and Chebplan construct makes the TRE posterior sampling suitable for GPU execution; a small update will be required before full GPU use is possible, i.e., keeping the summary statistics on GPU.